### PR TITLE
Fix #77: linspace count accepts float strings

### DIFF
--- a/lab_instruments/repl/commands/variables.py
+++ b/lab_instruments/repl/commands/variables.py
@@ -306,7 +306,7 @@ class VariableCommands(BaseCommand):
             try:
                 ls_start = float(ls_parts[1])
                 ls_stop = float(ls_parts[2])
-                ls_count = int(ls_parts[3]) if len(ls_parts) >= 4 else 11
+                ls_count = int(float(ls_parts[3])) if len(ls_parts) >= 4 else 11
                 if ls_count < 2:
                     raise ValueError("count must be >= 2")
                 ls_step = (ls_stop - ls_start) / (ls_count - 1)

--- a/lab_instruments/repl/script_engine/expander.py
+++ b/lab_instruments/repl/script_engine/expander.py
@@ -295,7 +295,7 @@ def expand_script_lines(
                 try:
                     ls_start = float(ls_parts[1])
                     ls_stop = float(ls_parts[2])
-                    ls_count = int(ls_parts[3]) if len(ls_parts) >= 4 else 11
+                    ls_count = int(float(ls_parts[3])) if len(ls_parts) >= 4 else 11
                     if ls_count < 2:
                         raise ValueError("count must be >= 2")
                     ls_step = (ls_stop - ls_start) / (ls_count - 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpi-instrument-toolkit"
-version = "1.0.10"
+version = "1.0.11"
 description = "Python drivers and interactive REPL for SCPI test and measurement instruments"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_repl_modules.py
+++ b/tests/test_repl_modules.py
@@ -839,6 +839,25 @@ class TestVariableCommands:
         monkeypatch.setattr("builtins.input", lambda prompt: "")
         vc.do_pause("")
 
+    def test_linspace_runtime_float_count(self, capsys):
+        """Regression for issue #77: runtime linspace with float-string count."""
+        vc, ctx = self._make()
+        vc._assign_var("V", "linspace 0 10 5.0")
+        vals = ctx.script_vars["V"].split()
+        assert len(vals) == 5
+        assert vals[0] == "0"
+        assert vals[-1] == "10"
+
+    def test_linspace_runtime_count_from_variable(self, capsys):
+        """Regression for issue #77: runtime linspace with count from variable."""
+        vc, ctx = self._make()
+        ctx.script_vars["n"] = "5.0"
+        vc._assign_var("V", "linspace 0 10 {n}")
+        vals = ctx.script_vars["V"].split()
+        assert len(vals) == 5
+        assert vals[0] == "0"
+        assert vals[-1] == "10"
+
 
 # ═══════════════════════════════════════════════════════════════════
 # 7. commands/general.py
@@ -1537,6 +1556,42 @@ class TestExpander:
         assert vals[0] == "0"
         assert vals[-1] == "1"
         assert vals[2] == "0.5"
+
+    def test_linspace_float_string_count(self):
+        """Regression for issue #77: linspace count given as float string (e.g. '5.0')."""
+        from lab_instruments.repl.script_engine.expander import expand_script_lines
+
+        ctx = self._make_ctx()
+        variables: dict = {}
+        expand_script_lines(["V = linspace 0 10 5.0"], variables, ctx)
+        vals = variables["V"].split()
+        assert len(vals) == 5
+        assert vals[0] == "0"
+        assert vals[-1] == "10"
+
+    def test_linspace_count_from_variable(self):
+        """Regression for issue #77: linspace count from variable resolving to float string."""
+        from lab_instruments.repl.script_engine.expander import expand_script_lines
+
+        ctx = self._make_ctx()
+        variables: dict = {"n": "5.0"}
+        expand_script_lines(["V = linspace 0 10 {n}"], variables, ctx)
+        vals = variables["V"].split()
+        assert len(vals) == 5
+        assert vals[0] == "0"
+        assert vals[-1] == "10"
+
+    def test_linspace_all_args_from_variables(self):
+        """Regression for issue #77: all linspace args from variables."""
+        from lab_instruments.repl.script_engine.expander import expand_script_lines
+
+        ctx = self._make_ctx()
+        variables: dict = {"lo": "0", "hi": "10.0", "n": "5"}
+        expand_script_lines(["V = linspace {lo} {hi} {n}"], variables, ctx)
+        vals = variables["V"].split()
+        assert len(vals) == 5
+        assert vals[0] == "0"
+        assert vals[-1] == "10"
 
     def test_linspace_with_for(self):
         from lab_instruments.repl.script_engine.expander import expand_script_lines


### PR DESCRIPTION
## Root Cause

`linspace` uses `int(ls_parts[3])` to parse the count argument. When a variable resolves to a float-format string like `"5.0"`, `int("5.0")` raises `ValueError`. The issue title's comment "string or int or float" refers to this: the count argument should accept any numeric format.

## What Changed

Changed `int(ls_parts[3])` to `int(float(ls_parts[3]))` in both:
- `lab_instruments/repl/script_engine/expander.py` (expansion-time path)
- `lab_instruments/repl/commands/variables.py` (runtime path)

This allows float-format strings like `"5.0"` to be correctly parsed as integer counts.

## How to Verify

```
start = 0
stop = 10
n = 5.0
V = linspace {start} {stop} {n}
print "{V}"
```

Should output `0 2.5 5 7.5 10` instead of erroring.

## Regression Tests Added

Five new tests in `tests/test_repl_modules.py`:
- `test_linspace_float_string_count` - literal float count like `5.0`
- `test_linspace_count_from_variable` - count from variable resolving to `"5.0"`
- `test_linspace_all_args_from_variables` - all three args from variables
- `test_linspace_runtime_float_count` - runtime path with float count
- `test_linspace_runtime_count_from_variable` - runtime path with variable count

Version bumped to 1.0.11.