### PR TITLE
Fix #87: repair REPL assignment grammar for multi-channel PSU + EV2300 reads

### DIFF
--- a/lab_instruments/repl/commands/variables.py
+++ b/lab_instruments/repl/commands/variables.py
@@ -91,8 +91,13 @@ class VariableCommands(BaseCommand):
         # Resolve the instrument: could be "dmm", "psu", "psu1", "smu", etc.
         # Known base types whose names embed digits (e.g. "ev2300") must not be
         # truncated by the trailing-digit strip -- mirrors DeviceRegistry.base_type.
+        # Suffixed aliases like "ev23001"/"ev23002" must resolve to "ev2300".
         _DIGIT_BEARING_TYPES = ("ev2300",)
-        base_type = instr_token if instr_token in _DIGIT_BEARING_TYPES else re.sub(r"\d+$", "", instr_token)
+        digit_bearing_type = next(
+            (typ for typ in _DIGIT_BEARING_TYPES if instr_token == typ or re.fullmatch(rf"{typ}\d+", instr_token)),
+            None,
+        )
+        base_type = digit_bearing_type or re.sub(r"\d+$", "", instr_token)
 
         # Check if it's a known instrument type
         known_types = ("dmm", "psu", "scope", "awg", "smu", "ev2300")
@@ -158,7 +163,9 @@ class VariableCommands(BaseCommand):
         """
         from .psu import _is_multi_channel, _resolve_channel
 
-        _MODE_TOKENS = ("v", "volt", "voltage", "i", "curr", "current")
+        _VOLTAGE_MODE_TOKENS = ("v", "volt", "voltage")
+        _CURRENT_MODE_TOKENS = ("i", "curr", "current")
+        _MODE_TOKENS = _VOLTAGE_MODE_TOKENS + _CURRENT_MODE_TOKENS
         ch_token = "1"
         mode_arg = ""
         if len(meas_args) >= 2:
@@ -171,16 +178,18 @@ class VariableCommands(BaseCommand):
                 ch_token = tok
 
         mode = mode_arg or self.ctx.last_instrument_mode.get(dev_name, "v")
+        if mode not in _MODE_TOKENS:
+            raise ValueError(f"Invalid PSU measurement mode: {mode}")
 
         if _is_multi_channel(dev):
             channel = _resolve_channel(dev, ch_token)
             if channel is None:
                 raise ValueError(f"Invalid PSU channel: {ch_token}")
-            if mode in ("i", "curr", "current"):
+            if mode in _CURRENT_MODE_TOKENS:
                 return dev.measure_current(channel), "A"
             return dev.measure_voltage(channel), "V"
 
-        if mode in ("i", "curr", "current"):
+        if mode in _CURRENT_MODE_TOKENS:
             return dev.measure_current(), "A"
         return dev.measure_voltage(), "V"
 
@@ -192,7 +201,9 @@ class VariableCommands(BaseCommand):
         """
         from .psu import _is_multi_channel, _resolve_channel
 
-        _MODE_TOKENS = ("v", "volt", "voltage", "i", "curr", "current")
+        _VOLTAGE_MODE_TOKENS = ("v", "volt", "voltage")
+        _CURRENT_MODE_TOKENS = ("i", "curr", "current")
+        _MODE_TOKENS = _VOLTAGE_MODE_TOKENS + _CURRENT_MODE_TOKENS
         ch_token = "1"
         mode_arg = ""
         if len(meas_args) >= 2:
@@ -205,16 +216,18 @@ class VariableCommands(BaseCommand):
                 ch_token = tok
 
         mode = mode_arg or self.ctx.last_instrument_mode.get(dev_name, "v")
+        if mode not in _MODE_TOKENS:
+            raise ValueError(f"Invalid SMU measurement mode: {mode}")
 
         if _is_multi_channel(dev):
             channel = _resolve_channel(dev, ch_token)
             if channel is None:
                 raise ValueError(f"Invalid SMU channel: {ch_token}")
-            if mode in ("i", "curr", "current"):
+            if mode in _CURRENT_MODE_TOKENS:
                 return dev.measure_current(channel), "A"
             return dev.measure_voltage(channel), "V"
 
-        if mode in ("i", "curr", "current"):
+        if mode in _CURRENT_MODE_TOKENS:
             return dev.measure_current(), "A"
         return dev.measure_voltage(), "V"
 

--- a/lab_instruments/repl/commands/variables.py
+++ b/lab_instruments/repl/commands/variables.py
@@ -34,8 +34,8 @@ _MODE_UNIT_MAP = {
     # SMU modes (same as PSU)
 }
 
-# Pattern: <instrument_alias> (read|meas) [args...] [unit=<override>]
-_INSTR_READ_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\s+(read|meas)(?:\s+(.*))?$")
+# Pattern: <instrument_alias> (read|meas|read_word|read_byte|read_block) [args...] [unit=<override>]
+_INSTR_READ_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\s+(read_word|read_byte|read_block|read|meas)(?:\s+(.*))?$")
 
 
 class VariableCommands(BaseCommand):
@@ -89,7 +89,10 @@ class VariableCommands(BaseCommand):
                 meas_args.append(token.lower())
 
         # Resolve the instrument: could be "dmm", "psu", "psu1", "smu", etc.
-        base_type = re.sub(r"\d+$", "", instr_token)
+        # Known base types whose names embed digits (e.g. "ev2300") must not be
+        # truncated by the trailing-digit strip -- mirrors DeviceRegistry.base_type.
+        _DIGIT_BEARING_TYPES = ("ev2300",)
+        base_type = instr_token if instr_token in _DIGIT_BEARING_TYPES else re.sub(r"\d+$", "", instr_token)
 
         # Check if it's a known instrument type
         known_types = ("dmm", "psu", "scope", "awg", "smu", "ev2300")
@@ -115,17 +118,14 @@ class VariableCommands(BaseCommand):
             self.ctx.command_had_error = True
             return True
 
-        # Determine measurement mode from args
-        mode_arg = meas_args[0] if meas_args else ""
-
         # Execute the measurement
         try:
             if base_type == "ev2300":
                 value, auto_unit = self._ev2300_read(dev, dev_name, _verb, meas_args)
             elif base_type == "smu":
-                value, auto_unit = self._smu_meas(dev, dev_name, mode_arg)
+                value, auto_unit = self._smu_meas(dev, dev_name, meas_args)
             elif base_type == "psu":
-                value, auto_unit = self._psu_meas(dev, dev_name, mode_arg)
+                value, auto_unit = self._psu_meas(dev, dev_name, meas_args)
             elif base_type == "scope":
                 value, auto_unit = self._scope_meas(dev, dev_name, meas_args)
             else:
@@ -147,16 +147,73 @@ class VariableCommands(BaseCommand):
         ColorPrinter.cyan(f"{varname} = {value}{suffix}")
         return True
 
-    def _psu_meas(self, dev, dev_name: str, mode_arg: str) -> tuple:
-        """Measure from PSU. Returns (value, auto_unit)."""
+    def _psu_meas(self, dev, dev_name: str, meas_args: list) -> tuple:
+        """Measure from PSU. Returns (value, auto_unit).
+
+        Accepted meas_args forms (see docs/psu.md):
+            []            -> channel 1, last-used mode (default 'v')
+            [mode]        -> channel 1, explicit mode (single-channel PSUs)
+            [ch]          -> explicit channel, last-used mode
+            [ch, mode]    -> explicit channel and mode
+        """
+        from .psu import _is_multi_channel, _resolve_channel
+
+        _MODE_TOKENS = ("v", "volt", "voltage", "i", "curr", "current")
+        ch_token = "1"
+        mode_arg = ""
+        if len(meas_args) >= 2:
+            ch_token, mode_arg = meas_args[0], meas_args[1]
+        elif len(meas_args) == 1:
+            tok = meas_args[0]
+            if tok in _MODE_TOKENS:
+                mode_arg = tok
+            else:
+                ch_token = tok
+
         mode = mode_arg or self.ctx.last_instrument_mode.get(dev_name, "v")
+
+        if _is_multi_channel(dev):
+            channel = _resolve_channel(dev, ch_token)
+            if channel is None:
+                raise ValueError(f"Invalid PSU channel: {ch_token}")
+            if mode in ("i", "curr", "current"):
+                return dev.measure_current(channel), "A"
+            return dev.measure_voltage(channel), "V"
+
         if mode in ("i", "curr", "current"):
             return dev.measure_current(), "A"
         return dev.measure_voltage(), "V"
 
-    def _smu_meas(self, dev, dev_name: str, mode_arg: str) -> tuple:
-        """Measure from SMU. Returns (value, auto_unit)."""
+    def _smu_meas(self, dev, dev_name: str, meas_args: list) -> tuple:
+        """Measure from SMU. Returns (value, auto_unit).
+
+        Mirrors _psu_meas: accepts the same [ch, mode] / [mode] / [ch] / []
+        forms so the assignment grammar stays consistent across PSU and SMU.
+        """
+        from .psu import _is_multi_channel, _resolve_channel
+
+        _MODE_TOKENS = ("v", "volt", "voltage", "i", "curr", "current")
+        ch_token = "1"
+        mode_arg = ""
+        if len(meas_args) >= 2:
+            ch_token, mode_arg = meas_args[0], meas_args[1]
+        elif len(meas_args) == 1:
+            tok = meas_args[0]
+            if tok in _MODE_TOKENS:
+                mode_arg = tok
+            else:
+                ch_token = tok
+
         mode = mode_arg or self.ctx.last_instrument_mode.get(dev_name, "v")
+
+        if _is_multi_channel(dev):
+            channel = _resolve_channel(dev, ch_token)
+            if channel is None:
+                raise ValueError(f"Invalid SMU channel: {ch_token}")
+            if mode in ("i", "curr", "current"):
+                return dev.measure_current(channel), "A"
+            return dev.measure_voltage(channel), "V"
+
         if mode in ("i", "curr", "current"):
             return dev.measure_current(), "A"
         return dev.measure_voltage(), "V"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpi-instrument-toolkit"
-version = "1.0.19"
+version = "1.0.20"
 description = "Python drivers and interactive REPL for SCPI test and measurement instruments"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpi-instrument-toolkit"
-version = "1.0.21"
+version = "1.0.22"
 description = "Python drivers and interactive REPL for SCPI test and measurement instruments"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpi-instrument-toolkit"
-version = "1.0.20"
+version = "1.0.21"
 description = "Python drivers and interactive REPL for SCPI test and measurement instruments"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_control_flow.py
+++ b/tests/test_control_flow.py
@@ -712,3 +712,62 @@ class TestIssue87SweepEndToEnd:
         # error out with "missing 1 required positional argument: 'channel'".
         assert repl.ctx.script_vars["readback"] == pytest.approx(25.0)
         assert psu.last_channel == 2
+
+
+# ---------------------------------------------------------------------------
+# CodeRabbit review follow-ups on PR #88:
+#   1. Suffixed ev2300 aliases (ev23001, ev23002) must resolve to "ev2300"
+#      instead of being stripped to "ev" by the generic trailing-digit strip.
+#   2. Unknown PSU/SMU measurement modes must raise ValueError instead of
+#      silently falling through to measure_voltage().
+# ---------------------------------------------------------------------------
+
+
+class TestSuffixedEV2300Aliases:
+    """A registered device named ``ev23001`` must still dispatch to the
+    ev2300 read handler — the assignment grammar's base_type resolution
+    must mirror DeviceRegistry.base_type for digit-bearing types."""
+
+    def test_assign_ev23001_read_word(self, make_repl):
+        ev = _StateTrackingEV2300()
+        repl = make_repl({"ev23001": ev})
+        repl.onecmd("code = ev23001 read_word 0x08 0x0C")
+        assert repl.ctx.command_had_error is False
+        assert repl.ctx.script_vars["code"] == 0x1234
+        assert ev.word_reads == [(0x08, 0x0C)]
+
+    def test_assign_ev23002_read_byte(self, make_repl):
+        ev = _StateTrackingEV2300()
+        repl = make_repl({"ev23002": ev})
+        repl.onecmd("b = ev23002 read_byte 0x08 0x00")
+        assert repl.ctx.command_had_error is False
+        assert repl.ctx.script_vars["b"] == 0x5A
+        assert ev.byte_reads == [(0x08, 0x00)]
+
+
+class TestInvalidMeasMode:
+    """Unknown PSU/SMU meas modes must raise ValueError (caught and surfaced
+    via command_had_error), never silently fall through to voltage. A typo
+    like ``psu meas 2 currnt`` would otherwise corrupt sweep data."""
+
+    def test_psu_meas_rejects_unknown_mode(self, repl_multi_psu, capsys):
+        repl_multi_psu.onecmd("v = psu meas 2 currnt")
+        assert repl_multi_psu.ctx.command_had_error is True
+        captured = capsys.readouterr()
+        assert "Invalid PSU measurement mode" in captured.out + captured.err
+        # The variable must not be assigned a phantom voltage reading.
+        assert "v" not in repl_multi_psu.ctx.script_vars
+        dev = repl_multi_psu.ctx.registry.get_device("psu1")
+        assert dev.v_reads == {1: 0, 2: 0, 3: 0}
+        assert dev.i_reads == {1: 0, 2: 0, 3: 0}
+
+    def test_smu_meas_rejects_unknown_mode(self, make_repl, capsys):
+        psu = _StateTrackingMultiChanPSU()
+        # Re-use the multi-channel PSU shape as an SMU stand-in; the
+        # assignment grammar treats them symmetrically.
+        repl = make_repl({"smu": psu})
+        repl.onecmd("i = smu meas 1 amps")
+        assert repl.ctx.command_had_error is True
+        captured = capsys.readouterr()
+        assert "Invalid SMU measurement mode" in captured.out + captured.err
+        assert "i" not in repl.ctx.script_vars

--- a/tests/test_control_flow.py
+++ b/tests/test_control_flow.py
@@ -446,9 +446,10 @@ class TestMockInstrumentControlFlow:
 class _StateTrackingMultiChanPSU:
     """Multi-channel PSU mock that tracks which channel was measured.
 
-    Values are deterministic per channel so assertions can be exact; the
-    per-channel read count is incremented on every call so this is not a
-    constant-returning stub (state tracking per project rules).
+    Values are deterministic per channel but reflect the last setpoint so
+    a sweep of `psu set 2 V; psu meas 2 v` reads back what was written.
+    Per-channel read and write counts are incremented on every call so this
+    is not a constant-returning stub (state tracking per project rules).
     """
 
     CHANNEL_FROM_NUMBER = {1: "P6V", 2: "P25V", 3: "N25V"}
@@ -456,6 +457,10 @@ class _StateTrackingMultiChanPSU:
     def __init__(self):
         self.v_reads = {1: 0, 2: 0, 3: 0}
         self.i_reads = {1: 0, 2: 0, 3: 0}
+        self.setpoints_v = {1: 6.0, 2: 25.0, 3: -25.0}
+        self.setpoints_i = {1: 0.10, 2: 0.25, 3: -0.25}
+        self.output_enabled = False
+        self.selected_channel = None
         self.last_channel = None
 
     def _ch_num(self, channel):
@@ -466,16 +471,29 @@ class _StateTrackingMultiChanPSU:
         n = self._ch_num(channel)
         self.v_reads[n] += 1
         self.last_channel = n
-        return {1: 6.0, 2: 25.0, 3: -25.0}[n]
+        return self.setpoints_v[n]
 
     def measure_current(self, channel):
         n = self._ch_num(channel)
         self.i_reads[n] += 1
         self.last_channel = n
-        return {1: 0.10, 2: 0.25, 3: -0.25}[n]
+        return self.setpoints_i[n]
+
+    def set_output_channel(self, channel, voltage, current=None):
+        n = self._ch_num(channel)
+        self.setpoints_v[n] = float(voltage)
+        if current is not None:
+            self.setpoints_i[n] = float(current)
+        self.last_channel = n
+
+    def select_channel(self, channel):
+        self.selected_channel = self._ch_num(channel)
+
+    def enable_output(self, state):
+        self.output_enabled = bool(state)
 
     def safe_all(self):
-        pass
+        self.output_enabled = False
 
 
 class _StateTrackingEV2300:
@@ -565,3 +583,132 @@ class TestAssignEV2300Read:
         assert repl_ev2300.ctx.script_vars["blk"] == "DE AD BE EF"
         dev = repl_ev2300.ctx.registry.get_device("ev2300")
         assert dev.block_reads == [(0x08, 0x20)]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end regression for issue #87: replay the student's sweep script
+# (linspace + for + psu set + ev2300 read_word + psu meas <ch> + log save).
+# If any of the four underlying bugs regress, this test fails rather than
+# returning silently with "No measurements recorded."
+# ---------------------------------------------------------------------------
+
+
+class TestIssue87SweepEndToEnd:
+    """Regression test for https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit/issues/87.
+
+    Runs the user's reported script through the full script engine (linspace
+    expansion, for-loop, command dispatch) and asserts that measurements are
+    recorded for every iteration and that `log save` produces a CSV with all
+    rows. Silently passing (empty log, no error) was the original symptom.
+    """
+
+    def test_student_sweep_records_all_measurements(self, make_repl, tmp_path, monkeypatch):
+        from lab_instruments.repl.commands import variables as variables_mod
+
+        psu = _StateTrackingMultiChanPSU()
+        ev = _StateTrackingEV2300()
+        repl = make_repl({"psu1": psu, "ev2300": ev})
+
+        monkeypatch.setattr(variables_mod.time, "sleep", lambda _secs: None)
+        # In script mode `log save <relative>` resolves under the scripts
+        # dir (see logging_cmd.py: `base = ctx.get_scripts_dir() if ctx.in_script`).
+        monkeypatch.setenv("SCPI_SCRIPTS_DIR", str(tmp_path))
+        monkeypatch.setenv("SCPI_DATA_DIR", str(tmp_path))
+
+        # The mock's safe_all() (fired by make_repl's scan) leaves output=False.
+        # The student's real session had the channel enabled before running the
+        # sweep, so prime it here — otherwise the `psu chan 2 off` assertion
+        # below would pass tautologically.
+        psu.output_enabled = True
+
+        csv_name = "ADC_digital_code.csv"
+        script_lines = [
+            "val = linspace 18 21.5 3",
+            "for v val",
+            '    print "Setting {v}V..."',
+            "    psu set 2 {v}",
+            "    sleep 0.3",
+            "    code = ev2300 read_word 0x08 0x0C",
+            "    readback = psu meas 2 v unit=V",
+            "end",
+            "psu chan 2 off",
+            'print "=== Sweep complete ==="',
+            "log print",
+            f"log save {csv_name}",
+        ]
+
+        repl._run_script_lines(script_lines)
+
+        # The sweep must not silently fail: no command-level errors.
+        assert repl.ctx.command_had_error is False
+
+        # Three iterations -> three code reads + three readback measurements.
+        entries = repl.ctx.measurements.entries
+        code_entries = [e for e in entries if e["label"] == "code"]
+        readback_entries = [e for e in entries if e["label"] == "readback"]
+        assert len(code_entries) == 3, f"expected 3 ev2300 reads, got {len(code_entries)}: {entries}"
+        assert len(readback_entries) == 3, f"expected 3 psu readbacks, got {len(readback_entries)}: {entries}"
+
+        # PSU channel 2 must have been written and read back three times each,
+        # and the final readback must match the final setpoint (21.5 V).
+        assert psu.v_reads[2] == 3
+        assert psu.setpoints_v[2] == pytest.approx(21.5)
+        assert readback_entries[-1]["value"] == pytest.approx(21.5)
+        assert readback_entries[-1]["unit"] == "V"
+
+        # EV2300 read_word must have been called with the documented args.
+        assert ev.word_reads == [(0x08, 0x0C), (0x08, 0x0C), (0x08, 0x0C)]
+        assert all(e["value"] == 0x1234 for e in code_entries)
+
+        # `psu chan 2 off` must have disabled the output.
+        assert psu.output_enabled is False
+
+        # `log save` must have written a CSV with header + 6 data rows (order
+        # preserved: code, readback, code, readback, code, readback).
+        csv_path = tmp_path / csv_name
+        assert csv_path.exists(), f"log save did not write {csv_path}"
+        lines = csv_path.read_text(encoding="utf-8").splitlines()
+        assert lines[0] == "label,value,unit,source"
+        data_rows = lines[1:]
+        assert len(data_rows) == 6
+        labels_in_order = [row.split(",")[0] for row in data_rows]
+        assert labels_in_order == [
+            "code",
+            "readback",
+            "code",
+            "readback",
+            "code",
+            "readback",
+        ]
+
+    def test_student_sweep_without_fix_would_fail(self, make_repl, monkeypatch):
+        """Tight assertion on the specific symptom from the bug report.
+
+        Before the fix, `psu meas 2 v unit=V` raised a TypeError from
+        `HP_E3631A.measure_voltage()` and `ev2300 read_word ...` fell
+        through to a literal string assignment. This test fails loudly if
+        either regression returns, independent of the broader log-save path.
+        """
+        from lab_instruments.repl.commands import variables as variables_mod
+
+        psu = _StateTrackingMultiChanPSU()
+        ev = _StateTrackingEV2300()
+        repl = make_repl({"psu1": psu, "ev2300": ev})
+        monkeypatch.setattr(variables_mod.time, "sleep", lambda _secs: None)
+
+        repl._run_script_lines(
+            [
+                "code = ev2300 read_word 0x08 0x0C",
+                "readback = psu meas 2 v unit=V",
+            ]
+        )
+
+        assert repl.ctx.command_had_error is False
+        # `code` must be the integer 0x1234, not the literal string
+        # "ev2300 read_word 0x08 0x0C" that the pre-fix fallthrough produced.
+        assert repl.ctx.script_vars["code"] == 0x1234
+        assert not isinstance(repl.ctx.script_vars["code"], str)
+        # `readback` must hold the float from measure_voltage(channel), not
+        # error out with "missing 1 required positional argument: 'channel'".
+        assert repl.ctx.script_vars["readback"] == pytest.approx(25.0)
+        assert psu.last_channel == 2

--- a/tests/test_control_flow.py
+++ b/tests/test_control_flow.py
@@ -435,3 +435,133 @@ class TestMockInstrumentControlFlow:
         mock_repl.onecmd('assert v > 4.0 "PSU voltage in range"')
         out = capsys.readouterr().out
         assert "PASS" in out
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #87: assignment grammar for multi-channel PSU
+# (v = psu meas <ch> v unit=V) and EV2300 reads (code = ev2300 read_word ...).
+# ---------------------------------------------------------------------------
+
+
+class _StateTrackingMultiChanPSU:
+    """Multi-channel PSU mock that tracks which channel was measured.
+
+    Values are deterministic per channel so assertions can be exact; the
+    per-channel read count is incremented on every call so this is not a
+    constant-returning stub (state tracking per project rules).
+    """
+
+    CHANNEL_FROM_NUMBER = {1: "P6V", 2: "P25V", 3: "N25V"}
+
+    def __init__(self):
+        self.v_reads = {1: 0, 2: 0, 3: 0}
+        self.i_reads = {1: 0, 2: 0, 3: 0}
+        self.last_channel = None
+
+    def _ch_num(self, channel):
+        inv = {v: k for k, v in self.CHANNEL_FROM_NUMBER.items()}
+        return inv.get(channel, channel if isinstance(channel, int) else 1)
+
+    def measure_voltage(self, channel):
+        n = self._ch_num(channel)
+        self.v_reads[n] += 1
+        self.last_channel = n
+        return {1: 6.0, 2: 25.0, 3: -25.0}[n]
+
+    def measure_current(self, channel):
+        n = self._ch_num(channel)
+        self.i_reads[n] += 1
+        self.last_channel = n
+        return {1: 0.10, 2: 0.25, 3: -0.25}[n]
+
+    def safe_all(self):
+        pass
+
+
+class _StateTrackingEV2300:
+    """EV2300 mock that tracks each read call; returns distinct values."""
+
+    def __init__(self):
+        self.word_reads = []
+        self.byte_reads = []
+        self.block_reads = []
+
+    def read_word(self, addr, reg):
+        self.word_reads.append((addr, reg))
+        return {"ok": True, "value": 0x1234}
+
+    def read_byte(self, addr, reg):
+        self.byte_reads.append((addr, reg))
+        return {"ok": True, "value": 0x5A}
+
+    def read_block(self, addr, reg):
+        self.block_reads.append((addr, reg))
+        return {"ok": True, "block": [0xDE, 0xAD, 0xBE, 0xEF]}
+
+    def safe_all(self):
+        pass
+
+
+@pytest.fixture
+def repl_multi_psu(make_repl):
+    return make_repl({"psu1": _StateTrackingMultiChanPSU()})
+
+
+@pytest.fixture
+def repl_ev2300(make_repl):
+    return make_repl({"ev2300": _StateTrackingEV2300()})
+
+
+class TestAssignPsuMeasWithChannel:
+    """Issue #87: `v = psu meas <ch> v unit=V` must forward the channel."""
+
+    def test_assign_psu_meas_with_channel_multi(self, repl_multi_psu):
+        repl_multi_psu.onecmd("v = psu meas 2 v unit=V")
+        assert repl_multi_psu.ctx.command_had_error is False
+        assert float(repl_multi_psu.ctx.script_vars["v"]) == 25.0
+        entry = repl_multi_psu.ctx.measurements.get_by_label("v")
+        assert entry is not None
+        assert entry["unit"] == "V"
+        assert float(entry["value"]) == 25.0
+        dev = repl_multi_psu.ctx.registry.get_device("psu1")
+        assert dev.v_reads[2] == 1
+        assert dev.last_channel == 2
+
+    def test_assign_psu_meas_with_channel_current(self, repl_multi_psu):
+        repl_multi_psu.onecmd("i = psu meas 3 i unit=A")
+        assert repl_multi_psu.ctx.command_had_error is False
+        assert float(repl_multi_psu.ctx.script_vars["i"]) == -0.25
+        entry = repl_multi_psu.ctx.measurements.get_by_label("i")
+        assert entry is not None
+        assert entry["unit"] == "A"
+        dev = repl_multi_psu.ctx.registry.get_device("psu1")
+        assert dev.i_reads[3] == 1
+        assert dev.last_channel == 3
+
+
+class TestAssignEV2300Read:
+    """Issue #87: `code = ev2300 read_word ...` must capture the value."""
+
+    def test_assign_ev2300_read_word(self, repl_ev2300):
+        repl_ev2300.onecmd("code = ev2300 read_word 0x08 0x0C")
+        assert repl_ev2300.ctx.command_had_error is False
+        assert repl_ev2300.ctx.script_vars["code"] == 0x1234
+        entry = repl_ev2300.ctx.measurements.get_by_label("code")
+        assert entry is not None
+        assert entry["value"] == 0x1234
+        dev = repl_ev2300.ctx.registry.get_device("ev2300")
+        assert dev.word_reads == [(0x08, 0x0C)]
+
+    def test_assign_ev2300_read_byte(self, repl_ev2300):
+        repl_ev2300.onecmd("b = ev2300 read_byte 0x08 0x00")
+        assert repl_ev2300.ctx.command_had_error is False
+        assert repl_ev2300.ctx.script_vars["b"] == 0x5A
+        dev = repl_ev2300.ctx.registry.get_device("ev2300")
+        assert dev.byte_reads == [(0x08, 0x00)]
+
+    def test_assign_ev2300_read_block(self, repl_ev2300):
+        repl_ev2300.onecmd("blk = ev2300 read_block 0x08 0x20")
+        assert repl_ev2300.ctx.command_had_error is False
+        assert repl_ev2300.ctx.script_vars["blk"] == "DE AD BE EF"
+        dev = repl_ev2300.ctx.registry.get_device("ev2300")
+        assert dev.block_reads == [(0x08, 0x20)]


### PR DESCRIPTION
## Summary
- Repairs the REPL assignment grammar `<var> = <instr> <verb> ...` so the documented syntax works end-to-end: `v = psu meas 2 v unit=V` forwards the channel to multi-channel PSUs, and `code = ev2300 read_word 0x08 0x0C` captures the returned word instead of falling through to a literal-string assignment. Closes #87.
- Four root causes in `lab_instruments/repl/commands/variables.py`: the `_INSTR_READ_RE` regex only matched `read|meas` (so `read_word` / `read_byte` / `read_block` fell through); `mode_arg = meas_args[0]` dropped the mode token when a channel was present; `_psu_meas` / `_smu_meas` never forwarded a channel to the driver; and `base_type = re.sub(r"\d+$", "", "ev2300")` collapsed `ev2300` to `ev`, which was rejected by `known_types`. Fixed the regex, added a digit-bearing-types guard mirroring `DeviceRegistry.base_type`, threaded the full `meas_args` into the PSU/SMU helpers, and rewrote those helpers to reuse `_resolve_channel` / `_is_multi_channel` from `psu.py` so the assignment path and the direct-command path share channel resolution. Drivers (`hp_e3631a.py` etc.) are untouched -- the direct-command path already proved them correct.
- Ships with 5 unit tests and 2 end-to-end regression tests in `tests/test_control_flow.py`. The end-to-end test replays the student's exact script (linspace + for-loop + psu set + sleep + ev2300 read_word + psu meas `<ch>` + psu chan off + log save) through `_run_script_lines` and asserts 6 measurements land in the store with the expected values, the PSU output transitions from enabled to disabled, and the generated CSV contains header + 6 rows in interleaved order. Verified to fail against pre-fix code reproducing the exact symptoms from the bug report (`No measurements recorded` and `missing 1 required positional argument: 'channel'`), and to pass against this branch.
- CodeRabbit CLI finding addressed: the mock PSU starts with `output_enabled=True` before the sweep runs so the `psu chan 2 off` assertion is a real state-change check, not a tautology.

## Test plan
- [x] `ruff check lab_instruments/ tests/` - clean
- [x] `ruff format --check lab_instruments/ tests/` - clean
- [x] `pytest tests/ -x --tb=short` - 3391 passed
- [x] Pre-fix code verification: checked out `variables.py@662ad2c` and confirmed both regression tests fail with the exact issue #87 symptoms; restored and confirmed they pass.
- [ ] Nightly build on `dev/nightly` runs green after merge trigger.
- [ ] Manual REPL smoke on real HP E3631A + EV2300 once the student rig is available.