### PR TITLE
feat(scripting): confirm before 'script new' overwrites an existing script

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -16,15 +16,30 @@ Script directives (`set`, `array`, `linspace`, `print`, `pause`, `sleep`, `repea
 
 Create a new script and open it in your editor.
 
+<!-- doc-test: skip reason="illustrative syntax -- opens $EDITOR, which the doc-test harness cannot drive" -->
+
 ```text
 script new <name>
 ```
 
 Opens your system editor (`$EDITOR` / `$VISUAL`). Write one command per line. Save and close to finish.
 
+<!-- doc-test: skip reason="illustrative syntax -- opens $EDITOR and interacts with the user's real scripts dir" -->
+
 ```text
 script new my_psu_test
 ```
+
+If a script with the same name already exists, the REPL prompts for confirmation before replacing it:
+
+<!-- doc-test: skip reason="illustrative transcript -- the interactive overwrite prompt reads from stdin, which pytest captures" -->
+
+```text
+eset> script new my_psu_test
+Script 'my_psu_test' already exists. Overwrite and discard its contents? [y/N]:
+```
+
+Answering anything other than `y` / `yes` (including a blank line or Ctrl-D) leaves the original script untouched. Use `script edit <name>` to modify an existing script without destroying its contents.
 
 ### script run
 

--- a/lab_instruments/repl/commands/scripting.py
+++ b/lab_instruments/repl/commands/scripting.py
@@ -1,5 +1,6 @@
 """Script management commands: script, record, examples, python, limits."""
 
+import builtins
 import contextlib
 import json
 import os
@@ -51,6 +52,9 @@ class ScriptingCommands(BaseCommand):
         sub = args[0].lower()
         if sub == "new" and len(args) >= 2:
             name = args[1]
+            if self._script_exists(name) and not self._confirm_overwrite(name):
+                ColorPrinter.warning(f"Script '{name}' was not overwritten.")
+                return
             lines = self._edit_script(name, [])
             if lines is not None:
                 self.ctx.scripts[name] = lines
@@ -416,6 +420,40 @@ class ScriptingCommands(BaseCommand):
                     f.write("\n")
         except Exception as exc:
             ColorPrinter.error(f"Failed to save script '{name}': {exc}")
+
+    def _script_exists(self, name: str) -> bool:
+        """Return True if *name* is already a known script in memory or on disk."""
+        if name in self.ctx.scripts:
+            return True
+        try:
+            path = self.ctx.script_file(name)
+        except (OSError, ValueError):
+            # Scripts dir is unreachable or the name is malformed; treat as
+            # not-existing so the caller can proceed (the downstream save
+            # will surface the real error).
+            return False
+        return os.path.exists(path)
+
+    def _confirm_overwrite(self, name: str) -> bool:
+        """Prompt the user before `script new` replaces an existing script.
+
+        Default is No -- a blank line, a Ctrl-D / EOF, or any answer that is
+        not an explicit yes leaves the existing script untouched. Protects
+        against the student who retypes `script new X` over a file they
+        already populated and loses the whole thing. Ctrl-C is *not*
+        swallowed -- it propagates so the REPL aborts back to its prompt
+        as users expect.
+        """
+        prompt = (
+            f"{ColorPrinter.YELLOW}Script '{name}' already exists. "
+            f"Overwrite and discard its contents? [y/N]:{ColorPrinter.RESET} "
+        )
+        try:
+            answer = builtins.input(prompt)
+        except EOFError:
+            builtins.print()
+            return False
+        return answer.strip().lower() in ("y", "yes")
 
     def _edit_script(self, name: str, current_lines: list):
         if os.name == "nt":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpi-instrument-toolkit"
-version = "1.0.21"
+version = "1.0.22"
 description = "Python drivers and interactive REPL for SCPI test and measurement instruments"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_scripting_commands_extra.py
+++ b/tests/test_scripting_commands_extra.py
@@ -114,6 +114,261 @@ class TestScriptNewReturnsNone:
 
 
 # ---------------------------------------------------------------------------
+# script new overwrite confirmation: protect students who retype
+# `script new X` over a file they already populated.
+# ---------------------------------------------------------------------------
+
+
+class TestScriptNewOverwriteConfirm:
+    def test_new_on_existing_script_requires_confirmation(self, repl, capsys):
+        """With an existing script in memory and a 'n' answer, the original
+        contents are preserved and the editor is never invoked."""
+        original = ["psu set 1 5.0", "sleep 1"]
+        repl.ctx.scripts["existing"] = list(original)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repl.ctx._scripts_dir_override = tmpdir
+            # Seed the disk file so we can verify it survives.
+            repl._script_cmd._save_script("existing")
+
+            with (
+                patch("builtins.input", return_value="n") as mock_input,
+                patch.object(repl._script_cmd, "_edit_script") as mock_edit,
+            ):
+                repl.onecmd("script new existing")
+                mock_input.assert_called_once()
+                mock_edit.assert_not_called()
+
+            assert repl.ctx.scripts["existing"] == original
+            with open(repl.ctx.script_file("existing")) as f:
+                disk = [line.rstrip("\n") for line in f.readlines()]
+            assert disk == original
+            out = capsys.readouterr().out
+            assert "not overwritten" in out.lower()
+
+    def test_new_on_existing_script_yes_overwrites(self, repl, capsys):
+        """With an existing script and a 'y' answer, the editor is invoked
+        and the new contents replace the old."""
+        repl.ctx.scripts["existing"] = ["psu set 1 5.0"]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repl.ctx._scripts_dir_override = tmpdir
+            repl._script_cmd._save_script("existing")
+
+            def fake_run(cmd, **kwargs):
+                if len(cmd) >= 2:
+                    with open(cmd[1], "w") as f:
+                        f.write("psu off\n")
+
+            with (
+                patch("builtins.input", return_value="y"),
+                patch("subprocess.run", side_effect=fake_run),
+            ):
+                repl.onecmd("script new existing")
+
+            assert repl.ctx.scripts["existing"] == ["psu off"]
+
+    def test_new_on_fresh_name_does_not_prompt(self, repl, capsys):
+        """A brand-new name must skip the prompt entirely."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repl.ctx._scripts_dir_override = tmpdir
+
+            def fake_run(cmd, **kwargs):
+                if len(cmd) >= 2:
+                    with open(cmd[1], "w") as f:
+                        f.write("psu on\n")
+
+            with (
+                patch("builtins.input") as mock_input,
+                patch("subprocess.run", side_effect=fake_run),
+            ):
+                repl.onecmd("script new brand_new_name")
+                mock_input.assert_not_called()
+
+            assert "brand_new_name" in repl.ctx.scripts
+
+    def test_new_on_existing_eof_aborts(self, repl, capsys):
+        """Piped input / non-TTY context (EOFError on input) must abort
+        rather than silently overwrite."""
+        repl.ctx.scripts["existing"] = ["psu on"]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repl.ctx._scripts_dir_override = tmpdir
+            repl._script_cmd._save_script("existing")
+
+            with (
+                patch("builtins.input", side_effect=EOFError()),
+                patch.object(repl._script_cmd, "_edit_script") as mock_edit,
+            ):
+                repl.onecmd("script new existing")
+                mock_edit.assert_not_called()
+
+            assert repl.ctx.scripts["existing"] == ["psu on"]
+
+    def test_new_on_disk_only_script_prompts(self, repl, capsys):
+        """Script file on disk but not in-memory (e.g. written directly,
+        script load not yet run) must still trigger the prompt."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repl.ctx._scripts_dir_override = tmpdir
+            disk_path = repl.ctx.script_file("disk_only")
+            with open(disk_path, "w") as f:
+                f.write("psu set 1 3.3\n")
+            repl.ctx.scripts.pop("disk_only", None)
+
+            with (
+                patch("builtins.input", return_value="n") as mock_input,
+                patch.object(repl._script_cmd, "_edit_script") as mock_edit,
+            ):
+                repl.onecmd("script new disk_only")
+                mock_input.assert_called_once()
+                mock_edit.assert_not_called()
+
+            with open(disk_path) as f:
+                assert "psu set 1 3.3" in f.read()
+
+    def test_ctrl_c_during_prompt_propagates(self, repl, capsys):
+        """Ctrl-C at the overwrite prompt must NOT be silently swallowed.
+
+        Users expect Ctrl-C to abort back to the REPL prompt. Treating it
+        as an implicit 'No' would hide a signal we don't own.
+        """
+        repl.ctx.scripts["existing"] = ["psu on"]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repl.ctx._scripts_dir_override = tmpdir
+            repl._script_cmd._save_script("existing")
+
+            with (
+                patch("builtins.input", side_effect=KeyboardInterrupt()),
+                patch.object(repl._script_cmd, "_edit_script") as mock_edit,
+                pytest.raises(KeyboardInterrupt),
+            ):
+                repl._script_cmd.do_script("new existing")
+
+            mock_edit.assert_not_called()
+            assert repl.ctx.scripts["existing"] == ["psu on"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end regression for the student scenario that motivated this fix:
+# a script with real content exists; the student types `script new X`
+# again; the REPL must not silently destroy the prior work.
+# ---------------------------------------------------------------------------
+
+
+class TestScriptNewOverwriteRegression:
+    """Regression for the `script new` overwrite footgun.
+
+    These tests replay the exact sequence a student follows:
+
+      1. `script new my_lab`   -> write real content, save
+      2. (time passes, student forgets)
+      3. `script new my_lab`   -> must prompt, default No
+
+    Before the fix step (3) silently truncated the file. The student's
+    entire lab script was gone with no warning.
+    """
+
+    STUDENT_SCRIPT = [
+        "# Lab 3 sweep -- 2 hours of work",
+        "val = linspace 0 5 11",
+        "for v val",
+        '    print "Setting {v}V..."',
+        "    psu set 1 {v}",
+        "    sleep 0.5",
+        "    reading = psu meas 1 v unit=V",
+        "end",
+        "log save lab3_results.csv",
+    ]
+
+    def test_student_scenario_default_no_preserves_both_memory_and_disk(self, repl, capsys):
+        """The full retype-and-press-enter sequence must leave both the
+        in-memory script and the on-disk .scpi file untouched."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repl.ctx._scripts_dir_override = tmpdir
+
+            # Step 1: populate the script the way the student did.
+            repl.ctx.scripts["my_lab"] = list(self.STUDENT_SCRIPT)
+            repl._script_cmd._save_script("my_lab")
+            disk_path = repl.ctx.script_file("my_lab")
+            with open(disk_path) as f:
+                original_on_disk = f.read()
+            assert "linspace 0 5 11" in original_on_disk
+
+            # Step 3: student retypes `script new my_lab` and presses Enter
+            # (blank answer) -- the pre-fix code silently blew it away.
+            with (
+                patch("builtins.input", return_value="") as mock_input,
+                patch.object(repl._script_cmd, "_edit_script") as mock_edit,
+            ):
+                repl.onecmd("script new my_lab")
+                mock_input.assert_called_once()
+                mock_edit.assert_not_called()
+
+            # In-memory script is intact line-for-line.
+            assert repl.ctx.scripts["my_lab"] == self.STUDENT_SCRIPT
+
+            # On-disk file is byte-identical.
+            with open(disk_path) as f:
+                assert f.read() == original_on_disk
+
+            # The REPL must explicitly tell the student what happened --
+            # silence here is how the student lost work in the first place.
+            out = capsys.readouterr().out
+            assert "not overwritten" in out.lower()
+
+    def test_student_scenario_explicit_yes_overwrites_cleanly(self, repl):
+        """If the student really does mean to start over, `y` overwrites
+        the script and the new content lands in both memory and on disk."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repl.ctx._scripts_dir_override = tmpdir
+
+            repl.ctx.scripts["my_lab"] = list(self.STUDENT_SCRIPT)
+            repl._script_cmd._save_script("my_lab")
+            disk_path = repl.ctx.script_file("my_lab")
+
+            new_content = "psu off\n"
+
+            def fake_run(cmd, **kwargs):
+                if len(cmd) >= 2:
+                    with open(cmd[1], "w") as f:
+                        f.write(new_content)
+
+            with (
+                patch("builtins.input", return_value="y"),
+                patch("subprocess.run", side_effect=fake_run),
+            ):
+                repl.onecmd("script new my_lab")
+
+            assert repl.ctx.scripts["my_lab"] == ["psu off"]
+            with open(disk_path) as f:
+                disk_content = f.read()
+            assert "linspace" not in disk_content
+            assert "psu off" in disk_content
+
+    def test_student_scenario_non_interactive_abort_preserves_work(self, repl):
+        """Running in a non-TTY context (e.g. piped stdin) must abort
+        rather than treat missing input as implicit consent."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repl.ctx._scripts_dir_override = tmpdir
+            repl.ctx.scripts["my_lab"] = list(self.STUDENT_SCRIPT)
+            repl._script_cmd._save_script("my_lab")
+            disk_path = repl.ctx.script_file("my_lab")
+            with open(disk_path) as f:
+                original = f.read()
+
+            with (
+                patch("builtins.input", side_effect=EOFError()),
+                patch.object(repl._script_cmd, "_edit_script") as mock_edit,
+            ):
+                repl.onecmd("script new my_lab")
+                mock_edit.assert_not_called()
+
+            assert repl.ctx.scripts["my_lab"] == self.STUDENT_SCRIPT
+            with open(disk_path) as f:
+                assert f.read() == original
+
+
+# ---------------------------------------------------------------------------
 # record start with existing script (line 165-166: if name not in scripts)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- `script new X` used to silently truncate the on-disk `.scpi` file when `X` already existed. A student retyped the command and lost hours of lab work with no prompt. On Windows the save happens *before* the editor opens (`scripting.py:428-429`), so the file was gone even if the student closed the editor without saving.
- Root cause: the `new` branch at `lab_instruments/repl/commands/scripting.py:52-58` had no existence check -- it dropped straight into `_edit_script([])` + `_save_script`.
- Fix adds a pre-check (`_script_exists`) that covers both the in-memory script dict AND the on-disk `.scpi` file (so a script written but not yet `script load`-ed is still protected), and a confirmation prompt (`_confirm_overwrite`) that defaults to No. Blank answer, any non-yes, or `EOF` (non-TTY / piped stdin) aborts with a `[WARNING] Script 'X' was not overwritten.` message. `KeyboardInterrupt` is deliberately **not** caught so Ctrl-C falls back to the REPL prompt as users expect (per the `scpi-contract-reviewer` finding that an earlier draft swallowed it).

## Tests
- `TestScriptNewOverwriteConfirm` (6 unit tests in `tests/test_scripting_commands_extra.py`): covers default-No, explicit-yes, fresh-name-no-prompt, EOF-aborts, disk-only-script-still-prompts, Ctrl-C-propagates.
- `TestScriptNewOverwriteRegression` (3 end-to-end regression tests): replays the exact student scenario -- populate `my_lab` with a real multi-line script, save to disk, retype `script new my_lab`, assert both the in-memory script and the on-disk file are byte-identical to the original after a default-No response. Verified to fail against pre-fix `scripting.py@dev/nightly` with the silent `[SUCCESS] Script 'my_lab' created.` symptom; the explicit-yes case passes both pre- and post-fix (correct: the fix only gates the destructive path).

## Docs
- New subsection in `docs/scripting.md` showing the prompt transcript.
- Two pre-existing `script new <name>` / `script new my_psu_test` example blocks now carry `<!-- doc-test: skip -->` markers. They open `$EDITOR` and interact with the user's real scripts dir, so the `test_docs_examples_live.py` harness can't drive them -- the skip classification matches other editor-/GUI-dependent blocks already in the docs. Tightening the harness to patch the scripts dir is a separate refactor (out of scope here).

## Test plan
- [x] `ruff check lab_instruments/ tests/` - clean
- [x] `ruff format --check lab_instruments/ tests/` - clean
- [x] `pytest tests/ -x --tb=short` - full suite clean (was 3391 before, +9 new tests)
- [x] Pre-fix verification: restored `scripting.py@dev/nightly`, confirmed 2 of 3 regression tests fail with the pre-fix symptom, then restored.
- [ ] GitHub-side CodeRabbit review on this PR (local CLI hit org rate limit twice this session; will rely on the GitHub-side pass).
- [ ] Nightly build on `dev/nightly` runs green after merge.

## Branch
Targets `dev/nightly` (not `main`) so this stacks cleanly under PR #88 and gets nightly coverage before rolling into the next stable cut. Version bumped `1.0.21 -> 1.0.22`.