### PR TITLE
Enforce negative-only sink current on NI PXIe-4139 SMU

### DIFF
--- a/docs/smu.md
+++ b/docs/smu.md
@@ -52,7 +52,7 @@ smu set -12.0 0.1    # negative voltage for four-quadrant operation
     Setting a voltage without a current limit uses whatever limit was set previously (default: 10 mA). Always specify the limit when powering an unknown DUT. DC source power is capped at 20 W and sink power at 12 W by the hardware.
 
 !!! tip "How to sink current"
-    Use `smu sink <current>` for sinking and `smu source <current>` for sourcing. The SMU acts as a programmable electronic load when sinking. By the standard 4-quadrant SMU convention, **negative current = sink from DUT** (current flows into the SMU) and **positive current = source into DUT**. `smu sink` rejects non-negative input with a `ValueError`; `smu source` rejects non-positive input. See [smu sink / smu source](#smu-sink--smu-source) below.
+    Use `smu sink <current>` for sinking and `smu source <current>` for sourcing. The SMU acts as a programmable electronic load when sinking. By the standard 4-quadrant SMU convention, **negative current = sink from DUT** (current flows into the SMU) and **positive current = source into DUT**. `smu sink` rejects non-negative input with a `ValueError`; `smu source` rejects non-positive input. See [smu sink / smu source](#smu-sink-smu-source) below.
 
 ---
 

--- a/docs/smu.md
+++ b/docs/smu.md
@@ -52,7 +52,7 @@ smu set -12.0 0.1    # negative voltage for four-quadrant operation
     Setting a voltage without a current limit uses whatever limit was set previously (default: 10 mA). Always specify the limit when powering an unknown DUT. DC source power is capped at 20 W and sink power at 12 W by the hardware.
 
 !!! tip "How to sink current"
-    Use `smu set_mode current` instead of `smu set`. In current mode, the SMU acts as a programmable electronic load — positive current = sink from DUT, negative current = source into DUT. See [smu set_mode](#smu-set_mode) below.
+    Use `smu sink <current>` for sinking and `smu source <current>` for sourcing. The SMU acts as a programmable electronic load when sinking. By the standard 4-quadrant SMU convention, **negative current = sink from DUT** (current flows into the SMU) and **positive current = source into DUT**. `smu sink` rejects non-negative input with a `ValueError`; `smu source` rejects non-positive input. See [smu sink / smu source](#smu-sink--smu-source) below.
 
 ---
 
@@ -99,14 +99,41 @@ smu set_mode current <i> [voltage_limit]
 
 ```bash
 smu set_mode voltage 3.3 0.1    # source 3.3 V with 100 mA current limit
-smu set_mode current 0.010 3.0  # sink 10 mA from DUT (electronic load), 3 V compliance
-smu set_mode current -0.5 5.0   # source 0.5 A into DUT, 5 V compliance
+smu set_mode current -0.010 3.0 # sink 10 mA from DUT (electronic load), 3 V compliance
+smu set_mode current 0.5 5.0    # source 0.5 A into DUT, 5 V compliance
 ```
 
 !!! note "Current mode polarity"
-    In current mode, **positive current = sink** (draw current from the DUT, acting as a load) and **negative current = source** (push current into the DUT). This is the standard four-quadrant SMU convention. Use positive values when the SMU is loading an LDO, regulator, or other voltage source.
+    In current mode, **negative current = sink** (draw current from the DUT, acting as a load) and **positive current = source** (push current into the DUT). This is the standard four-quadrant SMU convention. `smu set_mode current` accepts either sign. Use the dedicated `smu sink` / `smu source` commands below when you want strict sign enforcement.
 
 Safety limits (`upper_limit` / `lower_limit`) are enforced before the mode switch is applied.
+
+---
+
+## smu sink / smu source
+
+Configure current mode with strict sign enforcement.
+
+```bash
+smu sink   <current_A> [voltage_limit_V]   # current must be negative
+smu source <current_A> [voltage_limit_V]   # current must be positive
+```
+
+Both commands route to `set_current_mode` after validating the sign. They follow the standard 4-quadrant SMU convention: **negative current = sink** (current flows into the SMU from the DUT, SMU acts as a load) and **positive current = source** (current flows out of the SMU into the DUT).
+
+| Command | Accepts | Rejects |
+|---------|---------|---------|
+| `smu sink <i>` | `i < 0` (e.g. `-0.05`) | `i >= 0`; raises `ValueError("Sink current must be negative ...")` |
+| `smu source <i>` | `i > 0` (e.g. `0.05`) | `i <= 0`; raises `ValueError("Source current must be positive ...")` |
+
+```bash
+smu sink -0.010 3.0    # sink 10 mA from DUT, 3 V compliance
+smu sink 0.010         # ERROR: Sink current must be negative
+smu source 0.5 5.0     # source 0.5 A into DUT, 5 V compliance
+smu source -0.5        # ERROR: Source current must be positive
+```
+
+When validation fails, the SMU's mode and setpoint are left unchanged.
 
 ---
 

--- a/lab_instruments/mock_instruments.py
+++ b/lab_instruments/mock_instruments.py
@@ -909,6 +909,20 @@ class MockNI_PXIe_4139(MockPSU):
             self._voltage_limit = float(voltage_limit)
         self._output_mode = "current"
 
+    def set_sink_current(self, current: float, voltage_limit: float = None) -> None:
+        if current >= 0:
+            raise ValueError(
+                f"Sink current must be negative (got {current} A) - use set_source_current for positive current"
+            )
+        self.set_current_mode(current, voltage_limit)
+
+    def set_source_current(self, current: float, voltage_limit: float = None) -> None:
+        if current <= 0:
+            raise ValueError(
+                f"Source current must be positive (got {current} A) - use set_sink_current for negative current"
+            )
+        self.set_current_mode(current, voltage_limit)
+
     def get_output_mode(self) -> str:
         return self._output_mode
 

--- a/lab_instruments/repl/commands/smu.py
+++ b/lab_instruments/repl/commands/smu.py
@@ -42,6 +42,12 @@ class SmuCommand(BaseCommand):
             elif cmd_name == "set_mode":
                 self._handle_set_mode(args, dev, smu_name)
 
+            elif cmd_name == "sink":
+                self._handle_sink(args, dev, smu_name)
+
+            elif cmd_name == "source":
+                self._handle_source(args, dev, smu_name)
+
             elif cmd_name == "meas":
                 self._handle_meas(args, dev, smu_name)
 
@@ -99,6 +105,10 @@ class SmuCommand(BaseCommand):
                 "smu set_mode voltage <v> [current_limit]",
                 "smu set_mode current <i> [voltage_limit]",
                 "  - example: smu set_mode current 0.05 5.0",
+                "smu sink <current_A> [voltage_limit_V]   (current must be negative)",
+                "  - example: smu sink -0.05 5.0",
+                "smu source <current_A> [voltage_limit_V] (current must be positive)",
+                "  - example: smu source 0.05 5.0",
                 "smu meas [v|i|vi]",
                 "  - no arg or vi: atomic V+I+compliance in one call",
                 "  - assign + log: label = smu meas v [unit=V]",
@@ -171,6 +181,30 @@ class SmuCommand(BaseCommand):
             ColorPrinter.success(f"Mode: {SMUSourceMode.CURRENT}  {current}A{suffix}")
         else:
             ColorPrinter.warning("smu set_mode voltage|current ...")
+
+    def _handle_sink(self, args, dev, smu_name) -> None:
+        if len(args) < 2:
+            ColorPrinter.warning("Usage: smu sink <current_A> [voltage_limit_V]   (current must be negative)")
+            return
+        current = float(args[1])
+        voltage_limit = float(args[2]) if len(args) >= 3 else None
+        if not self.safety.check_psu_limits(smu_name, None, voltage=voltage_limit, current=current):
+            return
+        dev.set_sink_current(current, voltage_limit)
+        suffix = f"  voltage_limit={voltage_limit}V" if voltage_limit is not None else ""
+        ColorPrinter.success(f"Mode: {SMUSourceMode.CURRENT} (sink)  {current}A{suffix}")
+
+    def _handle_source(self, args, dev, smu_name) -> None:
+        if len(args) < 2:
+            ColorPrinter.warning("Usage: smu source <current_A> [voltage_limit_V] (current must be positive)")
+            return
+        current = float(args[1])
+        voltage_limit = float(args[2]) if len(args) >= 3 else None
+        if not self.safety.check_psu_limits(smu_name, None, voltage=voltage_limit, current=current):
+            return
+        dev.set_source_current(current, voltage_limit)
+        suffix = f"  voltage_limit={voltage_limit}V" if voltage_limit is not None else ""
+        ColorPrinter.success(f"Mode: {SMUSourceMode.CURRENT} (source)  {current}A{suffix}")
 
     def _handle_compliance(self, args, dev) -> None:
         state = dev.query_in_compliance()

--- a/lab_instruments/src/ni_pxie_4139.py
+++ b/lab_instruments/src/ni_pxie_4139.py
@@ -260,6 +260,26 @@ class NI_PXIe_4139:
         self._session.commit()
         self._session.initiate()
 
+    def set_sink_current(self, current: float, voltage_limit: float = None) -> None:
+        """Configure the SMU as a current sink. Sink current must be negative
+        (4-quadrant convention: current flows into the SMU from the DUT)."""
+        self._check_session()
+        if current >= 0:
+            raise ValueError(
+                f"Sink current must be negative (got {current} A) - use set_source_current for positive current"
+            )
+        self.set_current_mode(current, voltage_limit)
+
+    def set_source_current(self, current: float, voltage_limit: float = None) -> None:
+        """Configure the SMU as a current source. Source current must be positive
+        (4-quadrant convention: current flows out of the SMU into the DUT)."""
+        self._check_session()
+        if current <= 0:
+            raise ValueError(
+                f"Source current must be positive (got {current} A) - use set_sink_current for negative current"
+            )
+        self.set_current_mode(current, voltage_limit)
+
     def get_output_mode(self) -> str:
         """Return the active output mode: 'voltage' or 'current'."""
         self._check_session()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpi-instrument-toolkit"
-version = "1.0.20"
+version = "1.0.21"
 description = "Python drivers and interactive REPL for SCPI test and measurement instruments"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_ni_pxie_4139.py
+++ b/tests/test_ni_pxie_4139.py
@@ -387,6 +387,98 @@ class TestNIPXIe4139_CurrentMode:
 
 
 # ===========================================================================
+# Sink / source current sign enforcement (4-quadrant convention)
+# ===========================================================================
+
+
+class TestNIPXIe4139_SinkSourceSign:
+    def test_set_sink_current_negative_ok(self, ni_pxie_4139):
+        import nidcpower
+
+        smu, ms = ni_pxie_4139
+        smu.set_sink_current(-0.05, 5.0)
+        assert ms.current_level == pytest.approx(-0.05)
+        assert ms.voltage_limit == pytest.approx(5.0)
+        assert ms.output_function == nidcpower.OutputFunction.DC_CURRENT
+        assert smu._output_mode == "current"
+
+    def test_set_sink_current_positive_raises(self, ni_pxie_4139):
+        smu, _ms = ni_pxie_4139
+        with pytest.raises(ValueError, match="Sink current must be negative"):
+            smu.set_sink_current(0.05)
+
+    def test_set_sink_current_zero_raises(self, ni_pxie_4139):
+        smu, _ms = ni_pxie_4139
+        with pytest.raises(ValueError, match="Sink current must be negative"):
+            smu.set_sink_current(0.0)
+
+    def test_set_sink_current_below_min_raises(self, ni_pxie_4139):
+        smu, _ms = ni_pxie_4139
+        with pytest.raises(ValueError, match="Current must be between"):
+            smu.set_sink_current(-5.0)
+
+    def test_set_sink_current_invalid_does_not_mutate_state(self, ni_pxie_4139):
+        import nidcpower
+
+        smu, ms = ni_pxie_4139
+        smu.set_voltage_mode(3.3, 0.1)
+        baseline_func = ms.output_function
+        baseline_voltage = ms.voltage_level
+        with pytest.raises(ValueError, match="Sink current must be negative"):
+            smu.set_sink_current(0.05)
+        assert ms.output_function == baseline_func == nidcpower.OutputFunction.DC_VOLTAGE
+        assert ms.voltage_level == baseline_voltage
+        assert smu._output_mode == "voltage"
+
+    def test_set_source_current_positive_ok(self, ni_pxie_4139):
+        import nidcpower
+
+        smu, ms = ni_pxie_4139
+        smu.set_source_current(0.05, 5.0)
+        assert ms.current_level == pytest.approx(0.05)
+        assert ms.voltage_limit == pytest.approx(5.0)
+        assert ms.output_function == nidcpower.OutputFunction.DC_CURRENT
+        assert smu._output_mode == "current"
+
+    def test_set_source_current_negative_raises(self, ni_pxie_4139):
+        smu, _ms = ni_pxie_4139
+        with pytest.raises(ValueError, match="Source current must be positive"):
+            smu.set_source_current(-0.05)
+
+    def test_set_source_current_zero_raises(self, ni_pxie_4139):
+        smu, _ms = ni_pxie_4139
+        with pytest.raises(ValueError, match="Source current must be positive"):
+            smu.set_source_current(0.0)
+
+    def test_mock_sink_current_positive_raises(self):
+        from lab_instruments.mock_instruments import MockNI_PXIe_4139
+
+        mock = MockNI_PXIe_4139()
+        mock.set_voltage_mode(3.3, 0.1)
+        with pytest.raises(ValueError, match="Sink current must be negative"):
+            mock.set_sink_current(0.05)
+        assert mock._output_mode == "voltage"
+        assert mock._current_level == 0.0
+
+    def test_mock_source_current_negative_raises(self):
+        from lab_instruments.mock_instruments import MockNI_PXIe_4139
+
+        mock = MockNI_PXIe_4139()
+        with pytest.raises(ValueError, match="Source current must be positive"):
+            mock.set_source_current(-0.05)
+        assert mock._output_mode == "voltage"
+
+    def test_mock_sink_current_negative_ok(self):
+        from lab_instruments.mock_instruments import MockNI_PXIe_4139
+
+        mock = MockNI_PXIe_4139()
+        mock.set_sink_current(-0.05, 5.0)
+        assert mock._output_mode == "current"
+        assert mock._current_level == -0.05
+        assert mock._voltage_limit == 5.0
+
+
+# ===========================================================================
 # Samples to average
 # ===========================================================================
 

--- a/tests/test_smu_commands.py
+++ b/tests/test_smu_commands.py
@@ -263,6 +263,65 @@ class TestSmuSetMode:
         assert repl.devices["smu"]._output_mode == "voltage"  # mode unchanged
 
 
+class TestSmuSinkSource:
+    def test_sink_negative_current_ok(self, repl):
+        repl.onecmd("smu sink -0.05 5.0")
+        dev = repl.devices["smu"]
+        assert dev._output_mode == "current"
+        assert dev._current_level == pytest.approx(-0.05)
+        assert dev._voltage_limit == pytest.approx(5.0)
+
+    def test_sink_negative_current_no_voltage_limit(self, repl):
+        repl.onecmd("smu sink -0.01")
+        dev = repl.devices["smu"]
+        assert dev._output_mode == "current"
+        assert dev._current_level == pytest.approx(-0.01)
+
+    def test_sink_positive_rejected(self, repl, capsys):
+        repl.onecmd("smu sink 0.05")
+        out = capsys.readouterr().out
+        assert "Sink current must be negative" in out
+        dev = repl.devices["smu"]
+        assert dev._output_mode == "voltage"  # state unchanged
+        assert dev._current_level == 0.0
+
+    def test_sink_zero_rejected(self, repl, capsys):
+        repl.onecmd("smu sink 0")
+        out = capsys.readouterr().out
+        assert "Sink current must be negative" in out
+        assert repl.devices["smu"]._output_mode == "voltage"
+
+    def test_sink_missing_args_shows_usage(self, repl, capsys):
+        repl.onecmd("smu sink")
+        out = capsys.readouterr().out
+        assert "Usage: smu sink" in out
+
+    def test_source_positive_current_ok(self, repl):
+        repl.onecmd("smu source 0.05 5.0")
+        dev = repl.devices["smu"]
+        assert dev._output_mode == "current"
+        assert dev._current_level == pytest.approx(0.05)
+        assert dev._voltage_limit == pytest.approx(5.0)
+
+    def test_source_negative_rejected(self, repl, capsys):
+        repl.onecmd("smu source -0.05")
+        out = capsys.readouterr().out
+        assert "Source current must be positive" in out
+        dev = repl.devices["smu"]
+        assert dev._output_mode == "voltage"
+        assert dev._current_level == 0.0
+
+    def test_source_zero_rejected(self, repl, capsys):
+        repl.onecmd("smu source 0")
+        out = capsys.readouterr().out
+        assert "Source current must be positive" in out
+
+    def test_source_missing_args_shows_usage(self, repl, capsys):
+        repl.onecmd("smu source")
+        out = capsys.readouterr().out
+        assert "Usage: smu source" in out
+
+
 class TestSmuAvg:
     def test_set_avg(self, repl):
         repl.onecmd("smu avg 10")


### PR DESCRIPTION
## Summary
- Add `set_sink_current` and `set_source_current` to the NI PXIe-4139 SMU driver with strict sign validation (sink requires `current < 0`, source requires `current > 0`, both reject zero).
- Mirror methods on `MockNI_PXIe_4139` with identical validation.
- Add REPL subcommands `smu sink <current> [voltage_limit]` and `smu source <current> [voltage_limit]` that route to the new methods.
- Flip `docs/smu.md` to the standard 4-quadrant convention: **negative current = sink, positive current = source**.
- Existing `set_current_mode` and `smu set_mode current` are unchanged for backward compatibility.

## Why
The previous `set_current_mode` accepted any value in `[-MAX_CURRENT, +MAX_CURRENT]` regardless of source/sink intent. Per the standard 4-quadrant SMU convention, sinking current (current flowing into the SMU from the DUT, SMU acts as a load) is conventionally negative. This PR adds dedicated, sign-strict entry points so callers that explicitly want sink behavior get a `ValueError` on positive input rather than silently sourcing.

## Test plan
- [x] `pytest tests/test_ni_pxie_4139.py tests/test_smu_commands.py` — all new sign-enforcement tests pass.
- [x] `pytest tests/ -x` — full suite (3405 tests) passes.
- [x] `ruff check lab_instruments/ tests/` clean.
- [x] `ruff format --check lab_instruments/ tests/` clean.
- [x] `@scpi-contract-reviewer` approves the new methods (no critical findings; ordering parity with sibling setters via `_check_session()` added).

Bumps version to 1.0.21.