### PR TITLE
Fix #104: add setup-teststand.ps1 with end-to-end venv validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ irm "https://raw.githubusercontent.com/T-O-M-Tool-Oauto-Mationator/scpi-instrume
 
 That's it. It installs Python, git, and the toolkit automatically. Then jump to [Start the REPL](#start-the-repl).
 
+**Using NI TestStand?** After the line above, also run `setup-teststand.ps1` to create a TestStand-compatible venv on your `H:` drive and have the script validate it for you. See the [NI TestStand Setup guide](https://t-o-m-tool-oauto-mationator.github.io/scpi-instrument-toolkit/teststand.html) for details.
+
 ---
 
 ## Everyone Else — Install

--- a/docs/teststand.md
+++ b/docs/teststand.md
@@ -29,11 +29,11 @@ then the script has already done these steps for you:
 | Add Python and Scripts dirs to user PATH | Yes (winget package handles this) |
 | `pip install scpi-instrument-toolkit` (global) | Yes |
 | Install Claude Code | Yes |
-| **Create a TestStand-compatible venv** | **No - do this below** |
+| **Create a TestStand-compatible venv** | **No - run `setup-teststand.ps1` (see [section 3](#3-create-a-venv-on-a-mapped-drive))** |
 | **Configure TestStand Python adapter** | **No - do this below** |
 | Install NI-VISA / NI-DCPower system drivers | No - needs admin, install separately |
 
-So if you already ran the setup script, skip ahead to [Create the venv](#3-create-a-venv-on-a-mapped-drive). The first two sections only matter if you are setting up Python manually.
+So if you already ran the setup script, skip ahead to [Create the venv](#3-create-a-venv-on-a-mapped-drive) and use `setup-teststand.ps1` to finish the job. The first two sections only matter if you are setting up Python manually.
 
 ---
 
@@ -119,18 +119,61 @@ Even though `setup-tamu.ps1` already installs the toolkit globally, the TestStan
 - Per-project package versions do not collide with other classes
 - The TestStand Python adapter has a stable, known location to load packages from
 
-### Why a mapped drive (not a UNC path)?
+### Why a mapped drive (not a raw UNC path)?
 
-Python and TestStand both have known issues with UNC paths (`\\server\share\...`) as working directories. Windows will refuse with "UNC paths are not supported" when Python tries to operate from one.
+On TAMU lab machines, `H:\` is a **junction to your network home directory** (a `\\coe-fs.engr.tamu.edu\Ugrads\<NetID>\...` UNC share). You should always type the `H:\` path - tools like cmd.exe refuse to use raw UNC paths as a working directory ("UNC paths are not supported"), but they handle the `H:\` junction fine.
 
-- **DO NOT** use: `\\coe-fs.engr.tamu.edu\Ugrads\<NetID>\Documents\eset-453\.venv`
+- **DO NOT** type: `\\coe-fs.engr.tamu.edu\Ugrads\<NetID>\Documents\eset-453\.venv`
 - **USE** instead: `H:\Documents\eset-453\.venv`
-
-Your TAMU home directory is already mapped to a drive letter (`H:` by default). Use that.
 
 > Replace `H:\Documents\eset-453\` with your own mapped drive letter and project path throughout this guide.
 
-### Create the venv
+!!! note "Heads-up: Python's 'redirects, links or junctions' warning is harmless here"
+    When you create the venv, Python 3.12 will print:
+
+    > Actual environment location may have moved due to redirects, links or junctions.
+    > Requested location: "H:\\Documents\\eset-453\\.venv\\Scripts\\python.exe"
+    > Actual location:    "\\\\coe-fs.engr.tamu.edu\\Ugrads\\<NetID>\\Documents\\eset-453\\.venv\\Scripts\\python.exe"
+
+    This is **expected** because `H:\` resolves to that UNC share. It is informational only - the venv works correctly, `Activate.ps1` works, and TestStand can use the `H:\...\.venv` path without issue. See [issue #104](https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit/issues/104).
+
+### Option 1: Use `setup-teststand.ps1` (recommended)
+
+After `setup-tamu.ps1` has installed Python 3.12, run the helper script from the toolkit repo:
+
+```powershell
+.\setup-teststand.ps1
+```
+
+Or, if you have not cloned the repo:
+
+```powershell
+irm "https://raw.githubusercontent.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit/main/setup-teststand.ps1" | iex
+```
+
+What it does:
+
+- Picks `H:\Documents\scpi-workspace\` as the project root (or falls back to `%USERPROFILE%` if `H:\` is not mapped, with a warning)
+- Finds a real Python 3.12 from `setup-tamu.ps1` **or** `py install 3.12`
+- Creates `<project-root>\.venv` (or skips if one is already there)
+- Installs `scpi-instrument-toolkit` into the venv
+- **Validates** end-to-end: confirms `python312.dll` is loadable (the thing TestStand needs), confirms `lab_instruments` imports cleanly
+- Prints the exact TestStand adapter values to copy-paste
+
+Useful flags:
+
+| Flag | Purpose |
+|---|---|
+| `-ProjectName eset-453` | Use `H:\Documents\eset-453\` instead of `scpi-workspace`. |
+| `-Drive G` | Use a different drive letter (defaults to `H`). |
+| `-Recreate` | Wipe and rebuild the venv from scratch. |
+| `-NoPause` | Skip the "Press Enter to close" prompt. Useful when chaining scripts. |
+
+Skip ahead to [Configure the TestStand Python Adapter](#4-configure-the-teststand-python-adapter) if the script ran clean.
+
+### Option 2: Manual setup (if the script does not fit your workflow)
+
+#### Create the venv
 
 If you used Option A (`setup-tamu.ps1`):
 
@@ -144,7 +187,7 @@ If you used Option B (`py install 3.12`):
 "%LOCALAPPDATA%\Python\pythoncore-3.12-64\python.exe" -m venv H:\Documents\eset-453\.venv
 ```
 
-### Install the toolkit into the venv
+#### Install the toolkit into the venv
 
 ```cmd
 H:\Documents\eset-453\.venv\Scripts\pip.exe install scpi-instrument-toolkit
@@ -160,13 +203,24 @@ H:\Documents\eset-453\.venv\Scripts\pip.exe install -r H:\Documents\eset-453\req
 > takes 30-60 seconds and the pip install can take several minutes depending on network
 > conditions. This is normal - do not cancel. Wait for the prompt to return before continuing.
 
-### Verify the venv
+#### Verify the venv
 
-```cmd
-H:\Documents\eset-453\.venv\Scripts\python.exe -c "from lab_instruments import find_all; print('toolkit OK')"
+Run this in PowerShell - it confirms the three things TestStand actually depends on (real interpreter, loadable DLL, importable toolkit) in one shot:
+
+```powershell
+& "H:\Documents\eset-453\.venv\Scripts\python.exe" -c @"
+import sys, ctypes.util
+print('python:', sys.version.split()[0])
+print('exe:', sys.executable)
+dll = ctypes.util.find_library('python3.12')
+print('python3.12.dll:', dll if dll else '<not found>')
+assert dll, 'python3.12.dll not on PATH - TestStand will refuse to load this interpreter.'
+from lab_instruments import find_all
+print('lab_instruments: OK')
+"@
 ```
 
-Should print `toolkit OK`.
+You should see four lines printed and no traceback. If `python3.12.dll: <not found>` or the assertion fires, TestStand will not be able to load this interpreter even though the venv works on the command line - go back to [section 2](#2-install-a-real-python-312-no-admin-required) and confirm a real Python is on PATH.
 
 ---
 
@@ -363,7 +417,13 @@ We standardize on **3.12** in this guide because it is the latest version suppor
 
 ## 9. Rebuilding the Venv
 
-If you need to start over (corrupted install, wrong Python version baked in, etc.):
+If you need to start over (corrupted install, wrong Python version baked in, etc.), the script handles this with the `-Recreate` flag:
+
+```powershell
+.\setup-teststand.ps1 -Recreate
+```
+
+Or do it manually:
 
 ```cmd
 rem Delete old venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpi-instrument-toolkit"
-version = "1.0.36"
+version = "1.0.37"
 description = "Python drivers and interactive REPL for SCPI test and measurement instruments"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/setup-teststand.ps1
+++ b/setup-teststand.ps1
@@ -1,0 +1,210 @@
+[CmdletBinding()]
+param(
+    [string]$ProjectName = "scpi-workspace",
+    [string]$Drive = "H:",
+    [switch]$Recreate,
+    [switch]$NoPause
+)
+
+# setup-teststand.ps1
+# Creates a TestStand-compatible Python venv on the user's network home drive
+# (default H:) so it survives roaming-profile resets on TAMU managed machines,
+# installs the toolkit into it, and validates that it actually works end-to-end.
+#
+# Run AFTER setup-tamu.ps1 (which installs Python 3.12 globally). Idempotent -
+# rerun any time. Pass -Recreate to wipe and rebuild the venv.
+
+function Wait-IfNeeded {
+    if (-not $NoPause) {
+        try { [void](Read-Host "Press Enter to close") } catch {}
+    }
+}
+
+function Write-Step { param($n, $msg)
+    Write-Host ""
+    Write-Host "[$n] $msg" -ForegroundColor Cyan
+    Write-Host ("-" * 60)
+}
+
+function Fail { param($msg)
+    Write-Host ""
+    Write-Host "ERROR: $msg" -ForegroundColor Red
+    Wait-IfNeeded
+    exit 1
+}
+
+Write-Host ("=" * 60)
+Write-Host "  SCPI Toolkit - NI TestStand venv setup"
+Write-Host "  No admin rights required"
+Write-Host ("=" * 60)
+
+# ---------------------------------------------------------------------------
+# Step 1: Pick a project root that survives roaming-profile resets
+# ---------------------------------------------------------------------------
+Write-Step 1 "Choosing project root..."
+
+$projectRoot = $null
+$driveLetter = $Drive.TrimEnd(":").TrimEnd("\")
+$drivePath   = "${driveLetter}:\"
+
+if (Test-Path $drivePath) {
+    $projectRoot = Join-Path $drivePath "Documents\$ProjectName"
+    Write-Host "Mapped drive ${driveLetter}: detected." -ForegroundColor Green
+    Write-Host "Project root: $projectRoot" -ForegroundColor Cyan
+
+    # Detect that H: is a junction/redirect to a UNC share (TAMU lab default).
+    # The venv still works, but tell the student up front so the warning Python
+    # emits during venv creation is not alarming.
+    try {
+        $resolved = (Resolve-Path $drivePath -ErrorAction Stop).ProviderPath
+        if ($resolved -like "\\*") {
+            Write-Host ""
+            Write-Host "NOTE: ${driveLetter}:\ on this machine is a junction to a UNC share:" -ForegroundColor Yellow
+            Write-Host "      $resolved" -ForegroundColor Yellow
+            Write-Host "Python may print a 'redirects, links or junctions' warning when it" -ForegroundColor Yellow
+            Write-Host "creates the venv. This is informational - the venv WILL work." -ForegroundColor Yellow
+        }
+    } catch {
+        # Ignore - if Resolve-Path fails we'll let venv creation surface a real error
+    }
+} else {
+    $fallback = Join-Path $env:USERPROFILE "Documents\$ProjectName"
+    Write-Host "Mapped drive ${driveLetter}: was not found." -ForegroundColor Yellow
+    Write-Host "Falling back to local profile: $fallback" -ForegroundColor Yellow
+    Write-Host "WARNING: On TAMU managed machines the local profile may reset on" -ForegroundColor Yellow
+    Write-Host "         logout. If you have an H: drive but it is not connected," -ForegroundColor Yellow
+    Write-Host "         cancel now (Ctrl+C), reconnect it, and rerun this script." -ForegroundColor Yellow
+    $projectRoot = $fallback
+}
+
+New-Item -ItemType Directory -Force -Path $projectRoot | Out-Null
+$venvPath = Join-Path $projectRoot ".venv"
+
+# ---------------------------------------------------------------------------
+# Step 2: Find a real Python 3.12 (not the Microsoft Store stub)
+# ---------------------------------------------------------------------------
+Write-Step 2 "Locating Python 3.12..."
+
+$candidates = @(
+    (Join-Path $env:LOCALAPPDATA "Programs\Python\Python312\python.exe"),   # winget / setup-tamu.ps1
+    (Join-Path $env:LOCALAPPDATA "Python\pythoncore-3.12-64\python.exe")    # py install 3.12
+)
+
+$pythonExe = $null
+foreach ($cand in $candidates) {
+    if (Test-Path $cand) {
+        # Make sure this is not the Store stub by checking it actually runs.
+        $ver = & $cand --version 2>&1
+        if ($LASTEXITCODE -eq 0 -and $ver -match "^Python 3\.12") {
+            $pythonExe = $cand
+            Write-Host "Found: $pythonExe  ($ver)" -ForegroundColor Green
+            break
+        }
+    }
+}
+
+if (-not $pythonExe) {
+    Fail @"
+Could not find a real Python 3.12 install in a TestStand-compatible location.
+Run setup-tamu.ps1 first, or install manually with:
+    py install 3.12
+Expected locations checked:
+    %LOCALAPPDATA%\Programs\Python\Python312\python.exe
+    %LOCALAPPDATA%\Python\pythoncore-3.12-64\python.exe
+"@
+}
+
+# ---------------------------------------------------------------------------
+# Step 3: Create the venv (recreate if asked, skip if usable)
+# ---------------------------------------------------------------------------
+Write-Step 3 "Creating venv at $venvPath..."
+
+$venvPython = Join-Path $venvPath "Scripts\python.exe"
+
+if (Test-Path $venvPath) {
+    if ($Recreate) {
+        Write-Host "Removing existing venv (-Recreate specified)..." -ForegroundColor Yellow
+        Remove-Item -Recurse -Force $venvPath
+    } elseif (Test-Path $venvPython) {
+        Write-Host "Venv already exists and looks usable. Skipping creation." -ForegroundColor Yellow
+        Write-Host "(Pass -Recreate to wipe and rebuild.)" -ForegroundColor Yellow
+    } else {
+        Write-Host "Existing venv directory looks broken (no python.exe). Recreating..." -ForegroundColor Yellow
+        Remove-Item -Recurse -Force $venvPath
+    }
+}
+
+if (-not (Test-Path $venvPython)) {
+    & $pythonExe -m venv $venvPath
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $venvPython)) {
+        Fail "venv creation failed. See output above."
+    }
+    Write-Host "Venv created." -ForegroundColor Green
+}
+
+# ---------------------------------------------------------------------------
+# Step 4: Install the toolkit into the venv
+# ---------------------------------------------------------------------------
+Write-Step 4 "Installing scpi-instrument-toolkit into the venv..."
+Write-Host "(This can take several minutes on the TAMU network drive - be patient.)" -ForegroundColor Yellow
+
+$venvPip = Join-Path $venvPath "Scripts\pip.exe"
+& $venvPip install --upgrade pip 2>&1 | Out-Host
+& $venvPip install scpi-instrument-toolkit 2>&1 | Out-Host
+
+if ($LASTEXITCODE -ne 0) {
+    Fail "pip install scpi-instrument-toolkit failed. See output above."
+}
+
+# ---------------------------------------------------------------------------
+# Step 5: Validate the venv works end-to-end
+# ---------------------------------------------------------------------------
+Write-Step 5 "Validating the venv..."
+
+$validate = @"
+import sys, ctypes.util
+print('python:', sys.version.split()[0])
+print('exe:', sys.executable)
+dll = ctypes.util.find_library('python3.12')
+print('python3.12.dll:', dll if dll else '<not found>')
+assert dll, 'python3.12.dll not on PATH - TestStand will refuse to load this interpreter.'
+from lab_instruments import find_all  # toolkit import smoke test
+print('lab_instruments: OK')
+"@
+
+$tmpScript = New-TemporaryFile
+$validate | Set-Content -Path $tmpScript -Encoding UTF8
+try {
+    & $venvPython $tmpScript
+    if ($LASTEXITCODE -ne 0) {
+        Fail "Venv validation failed. See output above."
+    }
+} finally {
+    Remove-Item $tmpScript -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "Venv validated. python.exe runs, python3.12.dll is on PATH, and the" -ForegroundColor Green
+Write-Host "toolkit imports cleanly." -ForegroundColor Green
+
+# ---------------------------------------------------------------------------
+# Done - print TestStand adapter values to copy-paste
+# ---------------------------------------------------------------------------
+Write-Host ""
+Write-Host ("=" * 60)
+Write-Host "  Done - paste these values into TestStand" -ForegroundColor Green
+Write-Host ("=" * 60)
+Write-Host ""
+Write-Host "Configure > Adapters > Python > Configure"
+Write-Host ""
+Write-Host ("  Interpreter to use            : Global")
+Write-Host ("  Virtual environment (optional): {0}" -f $venvPath)
+Write-Host ("  Executable Path               : (leave blank - greyed out on managed machines)")
+Write-Host ("  Version                       : 3.12")
+Write-Host ""
+Write-Host "Then restart TestStand so it re-reads PATH."
+Write-Host ""
+Write-Host "Full guide: https://t-o-m-tool-oauto-mationator.github.io/scpi-instrument-toolkit/teststand.html"
+Write-Host ""
+
+Wait-IfNeeded


### PR DESCRIPTION
Closes #104.

## What broke

A student ran the documented venv command and got:

```text
Actual environment location may have moved due to redirects, links or junctions.
  Requested location: "H:\Documents\eset-453\.venv\Scripts\python.exe"
  Actual location:    "\\coe-fs.engr.tamu.edu\Ugrads\NashM03\Documents\eset-453\.venv\Scripts\python.exe"
```

The venv actually works (`Activate.ps1` succeeded, the student got a `(.venv)` prompt). But:

- The doc claimed "use `H:\` to avoid UNC issues". On TAMU lab machines, `H:\` is itself a junction to the `\\coe-fs.engr.tamu.edu\...` UNC share, so Python 3.12 sees through the junction and warns. The "use H: to avoid UNC" framing was misleading.
- The student had to type a multi-step command sequence by hand and had no quick way to verify the venv was actually TestStand-ready.

## Fixes

**New `setup-teststand.ps1`** — idempotent helper that picks up where `setup-tamu.ps1` leaves off:

- Picks `H:\Documents\<ProjectName>\` (default: `scpi-workspace`) as the project root; falls back to `%USERPROFILE%` with a loud warning if `H:` is not mapped.
- Detects when `H:\` resolves to a UNC share and tells the student up front so the Python warning is not alarming.
- Finds a real Python 3.12 from either `setup-tamu.ps1`'s winget install **or** `py install 3.12`.
- Creates the venv (skips if usable; `-Recreate` to wipe).
- `pip install scpi-instrument-toolkit` into the venv.
- **Validates end-to-end**: runs a Python snippet that asserts `python3.12.dll` is loadable (the thing TestStand actually fails on) and `lab_instruments` imports cleanly. Fails loud if either is broken.
- Prints the exact TestStand adapter values to copy-paste.
- Flags: `-ProjectName`, `-Drive`, `-Recreate`, `-NoPause`.

**`docs/teststand.md`**:
- Reworked the "Why a mapped drive" section to be honest: `H:` is a junction to a UNC share on TAMU lab machines; the redirects/junctions warning is expected and harmless. Linked to #104.
- Promoted the new script as **Option 1 (recommended)**; kept the manual flow as Option 2.
- Replaced the single-line `from lab_instruments import find_all` check with a fuller validation block that asserts the three things TestStand needs (real interpreter, loadable DLL, importable toolkit) in one shot.
- Updated "Rebuilding the Venv" to use `-Recreate`.

**`README.md`**: TestStand users now get a one-line pointer to the new script in the TAMU Start Here block.

**`pyproject.toml`**: 1.0.36 -> 1.0.37.

## Test plan
- [x] `mkdocs build` clean
- [ ] CI green
- [ ] Manual run of `setup-teststand.ps1` on a TAMU lab machine (will request a student to try after merge)
- [ ] Confirm the new validation block in the docs catches a missing `python3.12.dll` (e.g. if a student installs from Microsoft Store)