### PR TITLE
Fix #106: pip install needs the git+ URL (package is not on PyPI)

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -4,20 +4,26 @@
 
 - Python 3.10 or later (use **3.12** if you plan to drive the toolkit from NI TestStand - see [NI TestStand Setup](teststand.md))
 - pip
+- `git` on PATH (the install pulls from the GitHub repo - `pip install scpi-instrument-toolkit` does NOT work; the package is not on PyPI)
 
 ---
 
-## Install from PyPI
+## Install from GitHub
+
+The toolkit is distributed as a `git+https://` install, not a PyPI package. Run:
 
 ```bash
-pip install scpi-instrument-toolkit
+pip install "git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git"
 ```
 
 This installs the `scpi-repl` command and all required dependencies automatically.
 
+!!! warning "`scpi-instrument-toolkit` is NOT on PyPI"
+    Running `pip install scpi-instrument-toolkit` will fail with `Could not find a version that satisfies the requirement scpi-instrument-toolkit`. Always use the `git+https://...` form above.
+
 ---
 
-## Install from source
+## Install from source (for development)
 
 ```bash
 git clone https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git
@@ -37,16 +43,19 @@ pip install -e .
     ```powershell
     python --version
     pip --version
+    git --version
     ```
+
+    Then install with the git+ URL above. If you are on a TAMU managed machine and do not have git yet, run [`setup-tamu.ps1`](troubleshooting.md#first-time-setup-on-tamu-managed-windows-machines) first - it installs git and Python in one shot.
 
     If `scpi-repl` is not recognised after install, see [Troubleshooting](troubleshooting.md).
 
 === "macOS"
-    Install Python via [Homebrew](https://brew.sh) (recommended):
+    Install Python and git via [Homebrew](https://brew.sh) (recommended):
 
     ```bash
-    brew install python
-    pip3 install scpi-instrument-toolkit
+    brew install python git
+    pip3 install "git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git"
     ```
 
     Or download the macOS installer from [python.org](https://www.python.org/downloads/).
@@ -54,16 +63,16 @@ pip install -e .
 === "Linux (Debian/Ubuntu)"
     ```bash
     sudo apt update
-    sudo apt install python3 python3-pip
-    pip3 install scpi-instrument-toolkit
+    sudo apt install python3 python3-pip git
+    pip3 install "git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git"
     ```
 
     Serial instruments communicate via device files (`/dev/ttyUSB*`, `/dev/ttyACM*`) owned by the `dialout` group — your user must be a member. See [Troubleshooting](troubleshooting.md#serial-port-permission-denied-linux).
 
 === "Linux (Arch)"
     ```bash
-    sudo pacman -S python python-pip
-    pip install scpi-instrument-toolkit
+    sudo pacman -S python python-pip git
+    pip install "git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git"
     ```
 
     Serial instruments communicate via device files (`/dev/ttyUSB*`, `/dev/ttyACM*`) owned by the `uucp` group — your user must be a member. See [Troubleshooting](troubleshooting.md#serial-port-permission-denied-linux).
@@ -75,8 +84,8 @@ pip install -e .
 | Extra | Command | Purpose |
 |-------|---------|---------|
 | NI PXIe-4139 SMU | `pip install nidcpower` | NI DCPower driver for PXIe SMU — required only if you have NI PXIe-4139 hardware |
-| Docs build | `pip install "scpi-instrument-toolkit[docs]"` | Build HTML docs locally with MkDocs |
-| Test suite | `pip install "scpi-instrument-toolkit[test]"` | Run unit/integration tests |
+| Docs build | `pip install "scpi-instrument-toolkit[docs] @ git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git"` | Build HTML docs locally with MkDocs |
+| Test suite | `pip install "scpi-instrument-toolkit[test] @ git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git"` | Run unit/integration tests |
 
 ---
 
@@ -93,5 +102,11 @@ This launches the REPL with simulated instruments — no hardware required. Type
 ## Upgrading
 
 ```bash
-pip install --upgrade scpi-instrument-toolkit
+pip install --upgrade "git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git"
+```
+
+To pull the latest nightly:
+
+```bash
+pip install --upgrade --force-reinstall "git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git@dev/nightly"
 ```

--- a/docs/teststand.md
+++ b/docs/teststand.md
@@ -27,7 +27,7 @@ then the script has already done these steps for you:
 | Install git + GitHub Desktop + GitHub CLI | Yes |
 | Install Python 3.12 (user scope, no admin) | Yes |
 | Add Python and Scripts dirs to user PATH | Yes (winget package handles this) |
-| `pip install scpi-instrument-toolkit` (global) | Yes |
+| `pip install` toolkit from GitHub (global) | Yes |
 | Install Claude Code | Yes |
 | **Create a TestStand-compatible venv** | **No - run `setup-teststand.ps1` (see [section 3](#3-create-a-venv-on-a-mapped-drive))** |
 | **Configure TestStand Python adapter** | **No - do this below** |
@@ -189,9 +189,14 @@ If you used Option B (`py install 3.12`):
 
 #### Install the toolkit into the venv
 
+The toolkit is **not on PyPI** - it installs from the GitHub repo:
+
 ```cmd
-H:\Documents\eset-453\.venv\Scripts\pip.exe install scpi-instrument-toolkit
+H:\Documents\eset-453\.venv\Scripts\pip.exe install "git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git"
 ```
+
+!!! warning "`pip install scpi-instrument-toolkit` will fail"
+    You will see `ERROR: Could not find a version that satisfies the requirement scpi-instrument-toolkit` if you drop the `git+https://...` URL. The package is not published on PyPI - always use the URL form. See [issue #106](https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit/issues/106).
 
 If your lab has its own `requirements.txt`, install that instead:
 
@@ -432,8 +437,8 @@ rmdir /s /q H:\Documents\eset-453\.venv
 rem Recreate with Python 3.12 (use the path from your install Option above)
 "%LOCALAPPDATA%\Programs\Python\Python312\python.exe" -m venv H:\Documents\eset-453\.venv
 
-rem Reinstall the toolkit
-H:\Documents\eset-453\.venv\Scripts\pip.exe install scpi-instrument-toolkit
+rem Reinstall the toolkit (note: not on PyPI - install from GitHub)
+H:\Documents\eset-453\.venv\Scripts\pip.exe install "git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git"
 ```
 
 ---
@@ -468,3 +473,13 @@ NI-VISA cannot see any instruments. Open **NI MAX** and confirm your devices app
 ### `"\\server\share\..." is not supported`
 
 You created the venv on a UNC path. Delete it and recreate on a mapped drive letter ([section 3](#3-create-a-venv-on-a-mapped-drive)).
+
+### `ERROR: Could not find a version that satisfies the requirement scpi-instrument-toolkit`
+
+You typed `pip install scpi-instrument-toolkit` (or any variant ending in just the bare name). The package is **not on PyPI**; pip is searching the index, finding nothing, and giving up. Install from the GitHub repo instead:
+
+```cmd
+H:\Documents\eset-453\.venv\Scripts\pip.exe install "git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git"
+```
+
+If pip then complains that `git` is missing, install git via `setup-tamu.ps1` first.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpi-instrument-toolkit"
-version = "1.0.37"
+version = "1.0.38"
 description = "Python drivers and interactive REPL for SCPI test and measurement instruments"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/setup-teststand.ps1
+++ b/setup-teststand.ps1
@@ -147,13 +147,21 @@ if (-not (Test-Path $venvPython)) {
 # ---------------------------------------------------------------------------
 Write-Step 4 "Installing scpi-instrument-toolkit into the venv..."
 Write-Host "(This can take several minutes on the TAMU network drive - be patient.)" -ForegroundColor Yellow
+Write-Host "(The package is not on PyPI - we install directly from the GitHub repo.)" -ForegroundColor DarkGray
 
+$pkgUrl = "git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git"
 $venvPip = Join-Path $venvPath "Scripts\pip.exe"
 & $venvPip install --upgrade pip 2>&1 | Out-Host
-& $venvPip install scpi-instrument-toolkit 2>&1 | Out-Host
+& $venvPip install $pkgUrl 2>&1 | Out-Host
 
 if ($LASTEXITCODE -ne 0) {
-    Fail "pip install scpi-instrument-toolkit failed. See output above."
+    Fail @"
+pip install failed. See output above. The toolkit is NOT on PyPI - it installs
+from GitHub via:
+    pip install "$pkgUrl"
+Most common cause: git is not on PATH. Run setup-tamu.ps1 (which installs git)
+or install git manually, then rerun this script.
+"@
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #106.

## What broke

Student transcript (from the screenshot in #106):

\`\`\`
(.venv) PS C:\windows\system32> H:\Documents\eset-453\.venv\Scripts\pip.exe install scpi-instrument-toolkit-py
ERROR: Could not find a version that satisfies the requirement scpi-instrument-toolkit-py (from versions: none)
\`\`\`

The student added a stray \`-py\` suffix, but the real problem is upstream: even the correct bare name \`scpi-instrument-toolkit\` fails the same way. The package was never published to PyPI - \`release.yml\` builds sdist+wheel and attaches them to the GitHub Release, but there is no twine/PyPI upload step. So every \`pip install scpi-instrument-toolkit\` in the docs and scripts has been broken.

\`\`\`
$ curl -sI https://pypi.org/pypi/scpi-instrument-toolkit/json | head -1
HTTP/2 404
\`\`\`

## Fixes

- **\`docs/install.md\`**: rewrite \"Install from PyPI\" -> \"Install from GitHub\". Every platform tab now shows the \`git+https://...\` form. Added \`git\` to the requirements list. Loud warning explaining the bare PyPI name will fail.
- **\`docs/teststand.md\`**: venv install command updated to git+ URL. New troubleshooting entry for the exact \`Could not find a version that satisfies the requirement scpi-instrument-toolkit\` error linking to #106. Rebuild-venv block updated.
- **\`setup-teststand.ps1\`**: installs via the git+ URL. The failure message now tells students the toolkit is not on PyPI and lists the most common cause (no git on PATH) with the exact command to use.
- **\`pyproject.toml\`**: 1.0.37 -> 1.0.38.

\`setup-tamu.ps1\` was already correct (uses the git+ URL on line 295). \`README.md\` was already correct. So the bug was confined to the install-from-PyPI docs and the new TestStand venv flow.

## Followup (not in this PR)

Add a PyPI publish step to \`release.yml\` so \`pip install scpi-instrument-toolkit\` actually works. Lower priority since the git+ URL works everywhere; happy to file a separate issue.

## Test plan
- [x] \`mkdocs build\` clean
- [ ] CI green
- [ ] Spot-check the rendered docs - install.md and teststand.md both show the git+ URL form
- [ ] Verify a fresh \`pip install \"git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git\"\` resolves and installs cleanly (smoke test against the merged commit)