### PR TITLE
Fix #112: setup-teststand.ps1 pip self-upgrade + wrong DLL name

### DIFF
--- a/docs/teststand.md
+++ b/docs/teststand.md
@@ -45,7 +45,7 @@ You can verify this yourself by running:
 
 ```python
 import ctypes.util
-print(ctypes.util.find_library('python3.12'))  # prints None for Store installs
+print(ctypes.util.find_library('python312'))  # prints None for Store installs
 ```
 
 TestStand hits the same wall - it cannot find or load the DLL, and will show:
@@ -466,7 +466,7 @@ TestStand cannot find `python312.dll`. Verify in a fresh terminal:
 
 ```powershell
 where python
-python -c "import ctypes.util; print(ctypes.util.find_library('python3.12'))"
+python -c "import ctypes.util; print(ctypes.util.find_library('python312'))"
 ```
 
 If `where python` returns a path inside `C:\Program Files\WindowsApps\...`, you have the Microsoft Store stub - install a real Python via one of the [two options above](#2-install-a-real-python-312-no-admin-required).

--- a/docs/teststand.md
+++ b/docs/teststand.md
@@ -102,7 +102,7 @@ After either option, open a **new** terminal and run:
 
 ```powershell
 python --version
-python -c "import ctypes.util; print(ctypes.util.find_library('python3.12'))"
+python -c "import ctypes.util; print(ctypes.util.find_library('python312'))"
 ```
 
 The first should print `Python 3.12.x`. The second should print a path (not `None`). If both work, TestStand will find the DLL.
@@ -217,15 +217,15 @@ Run this in PowerShell - it confirms the three things TestStand actually depends
 import sys, ctypes.util
 print('python:', sys.version.split()[0])
 print('exe:', sys.executable)
-dll = ctypes.util.find_library('python3.12')
-print('python3.12.dll:', dll if dll else '<not found>')
-assert dll, 'python3.12.dll not on PATH - TestStand will refuse to load this interpreter.'
+dll = ctypes.util.find_library('python312')
+print('python312.dll:', dll if dll else '<not found>')
+assert dll, 'python312.dll not on PATH - TestStand will refuse to load this interpreter.'
 from lab_instruments import find_all
 print('lab_instruments: OK')
 "@
 ```
 
-You should see four lines printed and no traceback. If `python3.12.dll: <not found>` or the assertion fires, TestStand will not be able to load this interpreter even though the venv works on the command line.
+You should see four lines printed and no traceback. If `python312.dll: <not found>` or the assertion fires, TestStand will not be able to load this interpreter even though the venv works on the command line.
 
 **This means the base Python dir (the one that holds `python312.dll`) is not on your user PATH.** The venv's `Scripts\` directory does not contain `python312.dll` - only the base install does, so PATH must point to the base install for TestStand to find it. Fix it by either:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpi-instrument-toolkit"
-version = "1.0.40"
+version = "1.0.41"
 description = "Python drivers and interactive REPL for SCPI test and measurement instruments"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/setup-teststand.ps1
+++ b/setup-teststand.ps1
@@ -150,10 +150,16 @@ Write-Host "(This can take several minutes on the TAMU network drive - be patien
 Write-Host "(The package is not on PyPI - we install directly from the GitHub repo.)" -ForegroundColor DarkGray
 
 $pkgUrl = "git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git"
-$venvPip = Join-Path $venvPath "Scripts\pip.exe"
-& $venvPip install --upgrade pip 2>&1 | Out-Host
-& $venvPip install $pkgUrl 2>&1 | Out-Host
-
+# Use `python -m pip` to upgrade pip: on Windows, invoking pip.exe to upgrade
+# itself fails ("To modify pip, please run...") because pip cannot overwrite
+# its own running .exe. Also avoid `2>&1` on native commands - in PowerShell
+# 5.1 it wraps pip's stderr lines as NativeCommandError, burying the real
+# error in a wall of red and confusing users.
+& $venvPython -m pip install --upgrade pip
+if ($LASTEXITCODE -ne 0) {
+    Fail "pip self-upgrade failed. See output above."
+}
+& $venvPython -m pip install $pkgUrl
 if ($LASTEXITCODE -ne 0) {
     Fail @"
 pip install failed. See output above. The toolkit is NOT on PyPI - it installs
@@ -168,7 +174,7 @@ or install git manually, then rerun this script.
 # Step 4.5: Ensure the base Python dir is on user PATH
 # ---------------------------------------------------------------------------
 # TestStand loads python312.dll by searching PATH (the same lookup
-# ctypes.util.find_library('python3.12') performs). The base Python dir
+# ctypes.util.find_library('python312') performs). The base Python dir
 # - NOT the venv's Scripts dir - is what holds python312.dll. If a
 # previous setup-tamu.ps1 run did not persist this dir to user PATH (or
 # the user has not started a fresh shell since), validation below would
@@ -212,9 +218,9 @@ $validate = @"
 import sys, ctypes.util
 print('python:', sys.version.split()[0])
 print('exe:', sys.executable)
-dll = ctypes.util.find_library('python3.12')
-print('python3.12.dll:', dll if dll else '<not found>')
-assert dll, 'python3.12.dll not on PATH - TestStand will refuse to load this interpreter.'
+dll = ctypes.util.find_library('python312')
+print('python312.dll:', dll if dll else '<not found>')
+assert dll, 'python312.dll not on PATH - TestStand will refuse to load this interpreter.'
 from lab_instruments import find_all  # toolkit import smoke test
 print('lab_instruments: OK')
 "@
@@ -231,7 +237,7 @@ try {
 }
 
 Write-Host ""
-Write-Host "Venv validated. python.exe runs, python3.12.dll is on PATH, and the" -ForegroundColor Green
+Write-Host "Venv validated. python.exe runs, python312.dll is on PATH, and the" -ForegroundColor Green
 Write-Host "toolkit imports cleanly." -ForegroundColor Green
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #112.

## Summary

Three bugs in `setup-teststand.ps1` / `docs/teststand.md`. The first is what @nashm03-cloud actually hit in #112; the other two are latent bugs that PR #111 left behind.

### 1. `pip.exe install --upgrade pip` fails on Windows (the visible failure in #112)

On Windows, `pip.exe install --upgrade pip` exits non-zero with:

> ERROR: To modify pip, please run the following command: `python.exe -m pip install --upgrade pip`

…because pip cannot overwrite its own running `.exe`. Switch the script to `& $venvPython -m pip install --upgrade pip`, which is the form that works.

### 2. `2>&1 | Out-Host` on native commands obscures pip output as red errors

In PowerShell 5.1, redirecting a native exe's stderr inside a pipeline wraps each stderr line as a `NativeCommandError` ErrorRecord. That is why the screenshot in #112 shows pip's real error wrapped as `pip.exe : ... + FullyQualifiedErrorId : NativeCommandError` instead of the underlying `ERROR: To modify pip...` message. Drop the redirect and let pip write to the console naturally.

### 3. Validation looks for the wrong DLL (`python3.12.dll` doesn't exist)

`ctypes.util.find_library('python3.12')` searches PATH for `python3.12.dll`. On any standard CPython install the file is `python312.dll` (no dot). The lookup has always returned `None` even when the base Python dir was on PATH — meaning the Step 5 assertion fired for every fresh user, not just users with a broken PATH.

PR #111 mistook this for a PATH-not-set problem and added step 4.5 to add the base dir to user PATH. That step is still useful (TestStand really does need the dir on PATH), but the assertion would still fail because of the wrong filename. Verified locally on a TAMU lab machine:

```
[4.5] Ensuring base Python dir is on user PATH...
Already on user PATH: C:\Users\...\Programs\Python\Python312
[5] Validating the venv...
python3.12.dll: <not found>     <-- still fails
AssertionError: python3.12.dll not on PATH ...
```

After changing the lookup to `find_library('python312')` Step 5 passes:

```
python312.dll: C:\Users\...\Programs\Python\Python312\python312.dll
lab_instruments: OK
Venv validated. python.exe runs, python312.dll is on PATH, and the toolkit imports cleanly.
```

Applied the same correction to the two snippets in `docs/teststand.md` (the "Verify Python is on PATH" check after section 2, and the venv verification snippet after section 3).

Bump to 1.0.41.

## Pre-push checks

- Diff is scoped to `setup-teststand.ps1`, `docs/teststand.md`, and `pyproject.toml` — no changes under `lab_instruments/` or `tests/`, so `ruff` / `pytest` per CLAUDE.md aren't in scope.
- Docs deploy is automatic via `.github/workflows/docs.yml` on push to main.

## Test plan

- [x] Repro #112 on a TAMU lab machine: confirmed `pip.exe install --upgrade pip` fails with the in-use-binary error, surfaced as a wall of red by `2>&1`.
- [x] After fix: `setup-teststand.ps1 -ProjectName repro112-ws -Drive C -NoPause` completes end-to-end. pip upgrades cleanly (25.0.1 → 26.1.1), toolkit installs, Step 5 prints `python312.dll: <full path>` and `lab_instruments: OK`.
- [x] Confirmed `python3.12.dll` does not exist on this install — only `python3.dll` (stable ABI) and `python312.dll`. `find_library('python312')` resolves; `find_library('python3.12')` always returns None.
- [ ] @nashm03-cloud re-runs the one-liner `irm "https://raw.githubusercontent.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit/main/setup-teststand.ps1" | iex` after merge and confirms it completes through Step 5.