### PR TITLE
Sweep legacy LibreOffice install from setup/uninstall scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpi-instrument-toolkit"
-version = "1.0.41"
+version = "1.0.42"
 description = "Python drivers and interactive REPL for SCPI test and measurement instruments"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/setup-tamu.ps1
+++ b/setup-tamu.ps1
@@ -24,6 +24,51 @@ Write-Host "  No admin rights required"
 Write-Host ("=" * 60)
 
 # ---------------------------------------------------------------------------
+# Step 0: Remove legacy LibreOffice install (no longer used)
+# ---------------------------------------------------------------------------
+# Earlier versions of this script installed LibreOffice for the long-dead
+# docx/pptx preview feature. The feature was removed in 1.0.35 and the
+# install in 1.0.36 (#102), but students who ran the old script still have
+# it on disk. Its bundled `python312.dll` shadows the real Python 3.12 in
+# PATH-order-sensitive lookups (ctypes.util.find_library, TestStand's DLL
+# search), so leaving it around causes confusing TestStand behavior. Sweep
+# it off before doing anything else.
+Write-Step 0 "Removing legacy LibreOffice install (no longer used)..."
+
+$libreDir = Join-Path $env:LOCALAPPDATA "Programs\LibreOffice"
+if (Test-Path $libreDir) {
+    if (Get-Command winget -ErrorAction SilentlyContinue) {
+        Write-Host "Found legacy LibreOffice at $libreDir - uninstalling via winget..." -ForegroundColor Yellow
+        winget uninstall --id TheDocumentFoundation.LibreOffice `
+            --silent --accept-source-agreements --disable-interactivity | Out-Host
+        # winget exits 20 when the package isn't registered (the old script
+        # used `msiexec /a`, which leaves no winget entry). The manual dir
+        # delete below handles that case; reset $LASTEXITCODE so the later
+        # winget-based steps don't see a stale non-zero from this call.
+        $global:LASTEXITCODE = 0
+    }
+    if (Test-Path $libreDir) {
+        Write-Host "winget did not remove the dir - deleting manually." -ForegroundColor Yellow
+        Remove-Item -Recurse -Force $libreDir -ErrorAction SilentlyContinue
+    }
+    $libreOnPath = Join-Path $libreDir "program"
+    $cur = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($cur) {
+        $filtered = ($cur -split ";") | Where-Object {
+            $_.TrimEnd("\").ToLowerInvariant() -ne $libreOnPath.TrimEnd("\").ToLowerInvariant()
+        }
+        $new = ($filtered -join ";")
+        if ($new -ne $cur) {
+            [Environment]::SetEnvironmentVariable("Path", $new, "User")
+            Write-Host "Removed $libreOnPath from user PATH." -ForegroundColor Green
+        }
+    }
+    Write-Host "Legacy LibreOffice removed." -ForegroundColor Green
+} else {
+    Write-Host "LibreOffice not present. Skipping." -ForegroundColor Yellow
+}
+
+# ---------------------------------------------------------------------------
 # Step 1: Install GitHub Desktop (includes bundled git) via winget
 # ---------------------------------------------------------------------------
 Write-Step 1 "Installing GitHub Desktop (includes git)..."

--- a/uninstall-tamu.ps1
+++ b/uninstall-tamu.ps1
@@ -21,6 +21,39 @@ Write-Host "  SCPI Toolkit - TAMU Managed Machine Uninstall"
 Write-Host ("=" * 60)
 
 # ---------------------------------------------------------------------------
+# Step 0: Remove legacy LibreOffice install (no longer used)
+# ---------------------------------------------------------------------------
+# Mirrors setup-tamu.ps1's Step 0. LibreOffice was installed by older
+# versions of the setup script and is no longer used - clean it up.
+Write-Step 0 "Removing legacy LibreOffice install (no longer used)..."
+
+$libreDir = Join-Path $env:LOCALAPPDATA "Programs\LibreOffice"
+if (Test-Path $libreDir) {
+    if (Get-Command winget -ErrorAction SilentlyContinue) {
+        winget uninstall --id TheDocumentFoundation.LibreOffice `
+            --silent --accept-source-agreements --disable-interactivity | Out-Host
+        $global:LASTEXITCODE = 0
+    }
+    if (Test-Path $libreDir) {
+        Remove-Item -Recurse -Force $libreDir -ErrorAction SilentlyContinue
+    }
+    $libreOnPath = Join-Path $libreDir "program"
+    $cur = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($cur) {
+        $filtered = ($cur -split ";") | Where-Object {
+            $_.TrimEnd("\").ToLowerInvariant() -ne $libreOnPath.TrimEnd("\").ToLowerInvariant()
+        }
+        $new = ($filtered -join ";")
+        if ($new -ne $cur) {
+            [Environment]::SetEnvironmentVariable("Path", $new, "User")
+        }
+    }
+    Write-Host "Legacy LibreOffice removed." -ForegroundColor Green
+} else {
+    Write-Host "LibreOffice not present. Skipping." -ForegroundColor Yellow
+}
+
+# ---------------------------------------------------------------------------
 # Step 1: Uninstall scpi-instrument-toolkit
 # ---------------------------------------------------------------------------
 Write-Step 1 "Uninstalling scpi-instrument-toolkit..."


### PR DESCRIPTION
## Summary

Older versions of `setup-tamu.ps1` installed LibreOffice via `msiexec /a` for the long-dead docx/pptx preview feature. The feature was removed in 1.0.35 (#100) and the install in 1.0.36 (#102), but everyone who ran the script before that still has it sitting in `%LOCALAPPDATA%\Programs\LibreOffice` with its `program\` directory on user PATH.

This isn't harmless. LibreOffice bundles its own `python312.dll`; `ctypes.util.find_library('python312')` and TestStand's DLL search both return whichever Python 3.12 DLL is first on PATH. On affected machines that is LibreOffice's bundled interpreter, not the real Python 3.12 the venv was built against — so TestStand silently loads a different runtime, which is the kind of confusion that makes a student think their venv is broken.

Caught during the verification pass for PR #114: scenario E (User PATH stripped of Python312, then re-added by setup-teststand.ps1's step 4.5) on this lab machine resolved `python312.dll` to LibreOffice's path instead of the real one. Removing LibreOffice makes the issue moot regardless of PATH ordering.

## What changed

Adds an idempotent **Step 0** to both `setup-tamu.ps1` and `uninstall-tamu.ps1`:

- Skip if `%LOCALAPPDATA%\Programs\LibreOffice` does not exist.
- Try `winget uninstall TheDocumentFoundation.LibreOffice --silent --accept-source-agreements --disable-interactivity`. This is a no-op for the `msiexec /a` installs we shipped (those leave no winget entry) but covers any student who installed via winget directly.
- Reset `$LASTEXITCODE` after the winget call so its "package not found" exit code 20 doesn't leak into later winget steps that gate on `$LASTEXITCODE` (Steps 1 and 5).
- Fall back to `Remove-Item -Recurse -Force` on the install dir — this is what actually clears the `msiexec /a` corpse.
- Strip `<libre>\program` from user PATH so the next shell doesn't still resolve `python.exe` / `python312.dll` there.

Bump to 1.0.42.

## Verified locally

This TAMU lab machine had the legacy install from the original setup-tamu.ps1 run:

| | Before | After |
|---|---|---|
| `Test-Path %LOCALAPPDATA%\Programs\LibreOffice` | True | False |
| `<...>\LibreOffice\program` on user PATH | True | False |
| `ctypes.util.find_library('python312')` | `...\LibreOffice\program\python312.dll` | `...\Programs\Python\Python312\python312.dll` |

Re-ran Step 0 a second time and it logged "LibreOffice not present. Skipping." — idempotent.

## Test plan

- [x] First run on a machine with the legacy install: dir removed, PATH cleaned, find_library now resolves to real Python 3.12.
- [x] Second run on the same machine (idempotent): clean skip, no errors.
- [ ] Fresh TAMU machine without LibreOffice: should print "LibreOffice not present. Skipping." and proceed to Step 1 normally.