### PR TITLE
Fix #118: §5 Step 1 success criterion = Status:Done, not Output pane

### DIFF
--- a/docs/teststand.md
+++ b/docs/teststand.md
@@ -309,8 +309,10 @@ In TestStand, **File > New > Sequence File**, then insert three steps in the **M
    - **Module Path**: browse to `teststand_hello.py`
    - **Function Name**: `check_connection`
 3. **Arguments** tab: empty (the function takes no parameters).
-4. Save the sequence, click **Execute > Run MainSequence**. The **Output** pane should show:
-   > `Python adapter is working correctly.`
+4. Save the sequence, click **Execute > Run MainSequence**. Look at the **Steps** pane — the Action row's **Status** column should read **Done** and the **Executions** pane (top-left) should show a green checkmark next to MainSequence. That is the success signal.
+
+!!! note "Why isn't `Python adapter is working correctly.` in the Output pane?"
+    TestStand's **Output** pane is a structured message log (note the `MESSAGE` column header), not a Python stdout console. The Python adapter captures `print()` output silently and does not surface it there by default. Don't worry about it — **Status: Done** means the function ran. If you really want to see the print, enable **Configure > Adapters > Python > Configure > Advanced > Display Output of Each Module** before running, or check the Report tab.
 
 ### Step 2 — Numeric Limit Test calling `get_voltage`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpi-instrument-toolkit"
-version = "1.0.43"
+version = "1.0.44"
 description = "Python drivers and interactive REPL for SCPI test and measurement instruments"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Closes #118.

@nashm03-cloud followed §5 Step 1 exactly: set Module Path to \`teststand_hello.py\`, Function Name to \`check_connection\`, ran the sequence. Step status went to **Done**, MainSequence got a green ✓ in the Executions pane. Then they checked the Output pane (because that's what PR #117 told them to do) and saw it empty except for a \`MESSAGE\` header — and reasonably opened an issue titled "No Output."

**The student already succeeded.** The previous docs lied: TestStand's Output pane is a structured message log, not a Python stdout console. The Python adapter captures \`print()\` output silently and doesn't route it there by default. The actual success signal for an Action step is the **Status** column on the Steps pane (\`Done\`) plus the green checkmark in Executions — both of which are visible in their screenshot.

This was my mistake in PR #117.

## What changed

\`docs/teststand.md\` §5 Step 1:
- Replaced "The **Output** pane should show: \`Python adapter is working correctly.\`" with "the Action row's **Status** column should read **Done** and the **Executions** pane should show a green checkmark next to MainSequence."
- Added a callout that explains why \`print()\` output doesn't appear in the Output pane and points at the Python adapter advanced option (\`Configure > Adapters > Python > Configure > Advanced > Display Output of Each Module\`) for anyone who wants to see it. Also notes the Report tab as an alternative.

Bumped to 1.0.44.

## Test plan

- [x] Sanity-checked locally that the Python function itself is fine — \`check_connection()\` prints the expected line when called directly.
- [ ] Verify in the live docs after the merge auto-deploys.
- [ ] @nashm03-cloud re-reads §5 Step 1, confirms their existing TestStand sequence already shows Status:Done so they can proceed to Step 2.