### PR TITLE
Auto-configure TestStand Python Adapter + add prereqs to docs §4

### DIFF
--- a/docs/teststand.md
+++ b/docs/teststand.md
@@ -246,7 +246,9 @@ Close and reopen PowerShell after either fix - PATH changes do not affect alread
 
 ## 4. Configure the TestStand Python Adapter
 
-Open TestStand, then go to **Configure > Adapters > Python > Configure**
+Open TestStand, then go to **Configure > Adapters > Python > Configure**.
+
+### Main tab
 
 | Field | Value |
 |---|---|
@@ -254,6 +256,16 @@ Open TestStand, then go to **Configure > Adapters > Python > Configure**
 | Virtual environment (optional) | `H:\Documents\eset-453\.venv` |
 | Executable Path | *(greyed out on managed machines - leave blank)* |
 | Version | `3.12` |
+
+### Advanced tab — **check this box, students miss it**
+
+- [x] **Display Console for Interpreter Sessions**
+
+Without this, every `print()` inside a Python step disappears silently — the step still runs and reports its Status, but you cannot see any of the diagnostic output the function produced. NI's own Python example bundled with TestStand lists this as a prerequisite. Issue #118 was a student concluding the smoke test was broken because this box was unchecked and they assumed Status:Done with no console meant nothing ran. (The COM property behind this checkbox is `PythonAdapter.DisplayConsoleForInterpreterSessions` — verified against TestStand 2025 Q3 64-bit.)
+
+### When else you need `pywin32`
+
+The toolkit itself does **not** need `pywin32` inside the venv to run any of the smoke-test steps in [section 5](#5-smoke-test-prove-the-wiring-works) or the instrument calls in [section 6](#6-calling-real-instruments-from-teststand). You only need to `pip install pywin32` into the venv if a Python step accepts TestStand's `SequenceContext`, `Engine`, or another `IDispatch` COM object as a parameter (which gives your Python code access to the running TestStand engine itself). None of our examples do this — but if you write one that does, the adapter will fail with `-17500: Unable to pass parameter as COM object. Make sure you have installed pywin32`. The fix is `H:\Documents\<your-project>\.venv\Scripts\pip.exe install pywin32` and a restart of the TestStand interpreter session.
 
 ### Notes
 
@@ -312,7 +324,7 @@ In TestStand, **File > New > Sequence File**, then insert three steps in the **M
 4. Save the sequence, click **Execute > Run MainSequence**. Look at the **Steps** pane — the Action row's **Status** column should read **Done** and the **Executions** pane (top-left) should show a green checkmark next to MainSequence. That is the success signal.
 
 !!! note "Why isn't `Python adapter is working correctly.` in the Output pane?"
-    TestStand's **Output** pane is a structured message log (note the `MESSAGE` column header), not a Python stdout console. The Python adapter captures `print()` output silently and does not surface it there by default. Don't worry about it — **Status: Done** means the function ran. If you really want to see the print, enable **Configure > Adapters > Python > Configure > Advanced > Display Output of Each Module** before running, or check the Report tab.
+    TestStand's **Output** pane is a structured message log (note the `MESSAGE` column header), not a Python stdout console. The Python adapter captures `print()` output silently and does not surface it there by default. Don't worry about it — **Status: Done** means the function ran. To make `print()` output visible, check the **Display Console for Interpreter Sessions** box under [Configure > Adapters > Python > Configure > Advanced](#advanced-tab-check-this-box-students-miss-it).
 
 ### Step 2 — Numeric Limit Test calling `get_voltage`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpi-instrument-toolkit"
-version = "1.0.44"
+version = "1.0.45"
 description = "Python drivers and interactive REPL for SCPI test and measurement instruments"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/setup-teststand.ps1
+++ b/setup-teststand.ps1
@@ -241,21 +241,119 @@ Write-Host "Venv validated. python.exe runs, python312.dll is on PATH, and the" 
 Write-Host "toolkit imports cleanly." -ForegroundColor Green
 
 # ---------------------------------------------------------------------------
-# Done - print TestStand adapter values to copy-paste
+# Step 6: Auto-configure the TestStand Python Adapter (if TestStand installed)
+# ---------------------------------------------------------------------------
+# Talks to TestStand.Engine.1 via COM (pywin32) and sets the three adapter
+# properties students would otherwise have to flip manually in
+# Configure > Adapters > Python > Configure:
+#   * PythonVersion                          = '3.12'
+#   * DisplayConsoleForInterpreterSessions   = True   (so print() is visible)
+#   * PythonVirtualEnvironmentPath           = <this venv>
+# Verified on TestStand 2025 Q3 (64-bit): setting these via COM persists across
+# engine instances with no explicit save call required.
+Write-Step 6 "Auto-configuring TestStand Python Adapter (if TestStand installed)..."
+
+$tsInstalled = $false
+foreach ($tsRoot in @(
+    "${env:ProgramFiles}\National Instruments\TestStand 2025\Bin\SeqEdit.exe",
+    "${env:ProgramFiles}\National Instruments\TestStand 2024\Bin\SeqEdit.exe",
+    "${env:ProgramFiles}\National Instruments\TestStand 2023\Bin\SeqEdit.exe"
+)) {
+    if (Test-Path $tsRoot) { $tsInstalled = $true; break }
+}
+
+if (-not $tsInstalled) {
+    Write-Host "TestStand not detected on this machine. Skipping auto-config." -ForegroundColor Yellow
+    Write-Host "(That's fine - just means you'll configure the adapter the first time you" -ForegroundColor Yellow
+    Write-Host " run TestStand. See the printed instructions below.)" -ForegroundColor Yellow
+} else {
+    # pywin32 is needed in the venv to talk COM. It's a small wheel, ~10 MB.
+    $venvPip = Join-Path $venvPath "Scripts\pip.exe"
+    & $venvPython -m pip show pywin32 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Installing pywin32 into the venv (needed to talk to TestStand COM)..." -ForegroundColor Cyan
+        & $venvPython -m pip install --quiet pywin32
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "pywin32 install failed - falling back to manual config." -ForegroundColor Yellow
+            $tsInstalled = $false
+        }
+    }
+}
+
+if ($tsInstalled) {
+    $configScript = @"
+import sys
+try:
+    import win32com.client as wc
+except ImportError:
+    print('pywin32 not importable; skipping COM configuration.')
+    sys.exit(2)
+try:
+    engine = wc.Dispatch('TestStand.Engine.1')
+except Exception as e:
+    print(f'Could not open TestStand.Engine.1: {e}')
+    sys.exit(3)
+try:
+    adapter = engine.GetAdapterByKeyName('Python Adapter')
+    before = {
+        'PythonVersion': adapter.PythonVersion,
+        'DisplayConsoleForInterpreterSessions': adapter.DisplayConsoleForInterpreterSessions,
+        'PythonVirtualEnvironmentPath': adapter.PythonVirtualEnvironmentPath,
+    }
+    print('BEFORE:', before)
+    adapter.PythonVersion = '3.12'
+    adapter.DisplayConsoleForInterpreterSessions = True
+    adapter.PythonVirtualEnvironmentPath = r'$venvPath'
+    after = {
+        'PythonVersion': adapter.PythonVersion,
+        'DisplayConsoleForInterpreterSessions': adapter.DisplayConsoleForInterpreterSessions,
+        'PythonVirtualEnvironmentPath': adapter.PythonVirtualEnvironmentPath,
+    }
+    print('AFTER: ', after)
+finally:
+    try:
+        engine.ShutDown(True)
+    except Exception:
+        pass
+"@
+    $cfgTmp = New-TemporaryFile
+    $configScript | Set-Content -Path $cfgTmp -Encoding UTF8
+    try {
+        & $venvPython $cfgTmp
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host ""
+            Write-Host "TestStand Python Adapter configured:" -ForegroundColor Green
+            Write-Host "  PythonVersion                        = 3.12" -ForegroundColor Green
+            Write-Host "  DisplayConsoleForInterpreterSessions = True" -ForegroundColor Green
+            Write-Host "  PythonVirtualEnvironmentPath         = $venvPath" -ForegroundColor Green
+            Write-Host "Restart TestStand to pick up the changes." -ForegroundColor Yellow
+        } else {
+            Write-Host "Auto-config returned exit $LASTEXITCODE - configure manually (see below)." -ForegroundColor Yellow
+        }
+    } finally {
+        Remove-Item $cfgTmp -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Done - print TestStand adapter values (auto-config or manual fallback)
 # ---------------------------------------------------------------------------
 Write-Host ""
 Write-Host ("=" * 60)
-Write-Host "  Done - paste these values into TestStand" -ForegroundColor Green
+Write-Host "  Done - TestStand adapter values" -ForegroundColor Green
 Write-Host ("=" * 60)
 Write-Host ""
 Write-Host "Configure > Adapters > Python > Configure"
 Write-Host ""
-Write-Host ("  Interpreter to use            : Global")
-Write-Host ("  Virtual environment (optional): {0}" -f $venvPath)
-Write-Host ("  Executable Path               : (leave blank - greyed out on managed machines)")
-Write-Host ("  Version                       : 3.12")
+Write-Host ("  Interpreter to use                       : Global")
+Write-Host ("  Virtual environment (optional)           : {0}" -f $venvPath)
+Write-Host ("  Executable Path                          : (leave blank - greyed out on managed machines)")
+Write-Host ("  Version                                  : 3.12")
 Write-Host ""
-Write-Host "Then restart TestStand so it re-reads PATH."
+Write-Host "Advanced tab:"
+Write-Host ("  [x] Display Console for Interpreter Sessions  (so print() is visible)")
+Write-Host ""
+Write-Host "Then restart TestStand so it re-reads PATH and the adapter config."
 Write-Host ""
 Write-Host "Full guide: https://t-o-m-tool-oauto-mationator.github.io/scpi-instrument-toolkit/teststand.html"
 Write-Host ""


### PR DESCRIPTION
## Summary

Two combined changes so a student never has to manually configure the TestStand Python Adapter UI:

1. **`setup-teststand.ps1` Step 6** — if TestStand 2023/2024/2025 is detected, install `pywin32` into the venv and use `TestStand.Engine.1` COM to set:
   - `PythonAdapter.PythonVersion = '3.12'`
   - `PythonAdapter.DisplayConsoleForInterpreterSessions = True` (the missing checkbox behind #118)
   - `PythonAdapter.PythonVirtualEnvironmentPath = <this venv>`
2. **`docs/teststand.md` §4** — explicit Main-tab/Advanced-tab/pywin32-when-needed sections so students who don't run the script (or hit the manual fallback) still see what to flip and why.

Bumps to 1.0.45.

## Verified findings (headless COM probe on this TAMU lab machine)

The TestStand Engine COM API confirms:

- `PythonAdapter.DisplayConsoleForInterpreterSessions` defaults to `False` on a fresh station — exactly why @nashm03-cloud filed #118.
- Setting these adapter properties **persists across engine instances automatically**, no explicit save call needed:

```
Round 1: BEFORE flip → False, AFTER flip → True, ShutDown engine
Round 2 (fresh engine, new process): DisplayConsoleForInterpreterSessions = True
PERSISTED? True
```

- `Step.Module.ModulePath`, `FunctionOrAttributeName`, `Parameters[]` are the actual property paths used by the Python adapter (matches what §5 already describes for students).
- `Parameters[0]` is always `'Return Value'`, auto-bound to a TestStand local — that's the mechanism by which a Python step's return value becomes the Numeric Limit Test Measurement.

## End-to-end script verification on this machine

```
[6] Auto-configuring TestStand Python Adapter (if TestStand installed)...
Installing pywin32 into the venv (needed to talk to TestStand COM)...
BEFORE: {'PythonVersion': '3.12', 'DisplayConsoleForInterpreterSessions': False, 'PythonVirtualEnvironmentPath': ''}
AFTER:  {'PythonVersion': '3.12', 'DisplayConsoleForInterpreterSessions': True, 'PythonVirtualEnvironmentPath': 'C:\Documents\step6-e2e\.venv'}

TestStand Python Adapter configured:
  PythonVersion                        = 3.12
  DisplayConsoleForInterpreterSessions = True
  PythonVirtualEnvironmentPath         = C:\Documents\step6-e2e\.venv
Restart TestStand to pick up the changes.
```

After verification I reset the adapter back to defaults so I don't leave the lab machine in a weird state. The reset script (`reset_adapter.py`) and the probe scripts live outside the repo.

## Behavior matrix

| Machine state | What Step 6 does |
|---|---|
| TestStand not installed | Prints `"TestStand not detected... Skipping auto-config"`, falls through to the manual printout (which still shows the new Advanced-tab Display Console hint). |
| TestStand installed, pywin32 not in venv | Installs pywin32, runs auto-config. |
| TestStand installed, pywin32 already in venv | Skips install, runs auto-config. |
| Auto-config fails (COM error, license issue) | Prints exit code, falls through to manual printout. |

The toolkit itself does **not** depend on pywin32 — only the script installs it when needed for the auto-config path. Students without TestStand never get pywin32 installed.

## Test plan

- [x] COM persistence verified (flip + reopen test).
- [x] End-to-end script run on this lab machine: detected TestStand, installed pywin32, set 3 properties, printed clear summary.
- [x] Reset adapter back to defaults after the test so the lab machine is back to its original state.
- [ ] CI green on the PR.
- [ ] Verify auto-deployed docs render §4's new subsections correctly.