### PR TITLE
Fix remaining manual smoke-test defects from PR #119 audit (D2/D3/D4/D7/D10-D20)

### DIFF
--- a/docs/teststand.md
+++ b/docs/teststand.md
@@ -522,7 +522,7 @@ Open the step's settings → **Arguments** tab → fill every row. Literal value
 For a **Numeric Limit Test** step using the Python adapter, the function's return value should populate `Step.Result.Numeric`, which is what the Limits comparison reads. If Measurement shows `0.0` even though your Python `print` shows the right value, walk through this list:
 
 1. **The function returns the value, not just prints it.** `print(voltage)` alone is not enough — the function body needs `return voltage`.
-2. **The function signature matches what TestStand calls.** TestStand passes Arguments-tab values by name; `def get_voltage()` and `def get_voltage(**kwargs)` both work, but a function with required positional args you didn't fill in fails earlier with [-17347](#run-time-error--17347-the-expression-cannot-be-empty).
+2. **The function signature matches what TestStand calls.** TestStand passes Arguments-tab values by name; `def get_voltage()` and `def get_voltage(**kwargs)` both work, but a function with required positional args you didn't fill in fails earlier with [-17347](#run-time-error-17347-the-expression-cannot-be-empty).
 3. **The step type is Test - Numeric Limit Test, not Action.** Action steps don't have a measurement.
 4. **The Numeric Measurement expression on the Limits tab is at its default.** The Python adapter wires the return value into `Step.Result.Numeric` for you; if someone edited that expression to read from somewhere else, restore the default.
 
@@ -565,7 +565,7 @@ Things that trip students up most often when wiring TestStand to this toolkit.
 - **The function has to `return` the value -- not just `print` it.** For a Numeric Limit Test, the Python return value goes into `Step.Result.Numeric`. `print(voltage)` alone leaves Measurement at `0.0`.
 - **Fill in every Arguments row.** A blank parameter cell raises `Run-Time Error -17347: The expression cannot be empty`. Use literal values, `Locals.X`, or `Parameters.Y`.
 - **`pip install scpi-instrument-toolkit` does not work.** The package is not on PyPI. Always install with the `git+https://...` URL.
-- **Verify the venv before wiring TestStand.** Run the `python312.dll` + `from lab_instruments import find_all` smoke test from [section 5](#5-verify-the-venv). If that fails on the command line, TestStand will fail the same way -- save yourself the dialog-box hunting.
+- **Verify the venv before wiring TestStand.** Run the `python312.dll` + `from lab_instruments import find_all` smoke test from [section 3](#verify-the-venv). If that fails on the command line, TestStand will fail the same way -- save yourself the dialog-box hunting.
 
 ---
 

--- a/lab_instruments/repl/commands/scripting.py
+++ b/lab_instruments/repl/commands/scripting.py
@@ -211,21 +211,52 @@ class ScriptingCommands(BaseCommand):
             name = args[1] if len(args) >= 2 else None
             if name == "all":
                 loaded = 0
+                py_written = 0
                 for ename, info in EXAMPLES.items():
                     lines = info.get("lines", [])
                     if lines:
                         self.ctx.scripts[ename] = lines
                         loaded += 1
-                ColorPrinter.success(f"Loaded {loaded} SCPI example scripts.")
+                    if info.get("code") and self._materialize_example_py(ename, info["code"]):
+                        py_written += 1
+                suffix = f" (plus {py_written} .py companion files)" if py_written else ""
+                ColorPrinter.success(f"Loaded {loaded} SCPI example scripts{suffix}.")
             elif name and name in EXAMPLES:
-                lines = EXAMPLES[name].get("lines", [])
+                info = EXAMPLES[name]
+                lines = info.get("lines", [])
+                py_written = False
+                if info.get("code"):
+                    py_written = self._materialize_example_py(name, info["code"])
                 if lines:
                     self.ctx.scripts[name] = lines
-                    ColorPrinter.success(f"Loaded example '{name}'.")
+                    suffix = " (+ Python companion)" if py_written else ""
+                    ColorPrinter.success(f"Loaded example '{name}'{suffix}.")
+                elif py_written:
+                    ColorPrinter.success(f"Loaded Python-only example '{name}'. Run with: python {name}.py")
                 else:
                     ColorPrinter.warning(f"'{name}' has no SCPI version. Use the .py file directly.")
             else:
                 ColorPrinter.warning(f"Example '{name}' not found.")
+
+    def _materialize_example_py(self, name: str, code: str) -> bool:
+        """Write the Python companion of an EXAMPLES entry to the scripts dir.
+
+        Returns True on success. ``[scpi+py]`` examples (e.g. cross_script_demo)
+        contain a SCPI line like ``python cross_script_demo.py``; for that to
+        resolve, the .py has to actually live on disk somewhere the ``python``
+        command can find it. The scripts dir is the same place ``script new``
+        writes ``.scpi`` files.
+        """
+        try:
+            scripts_dir = self.ctx.get_scripts_dir()
+            os.makedirs(scripts_dir, exist_ok=True)
+            path = os.path.join(scripts_dir, f"{name}.py")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(code)
+            return True
+        except OSError as exc:
+            ColorPrinter.warning(f"Could not write Python companion for '{name}': {exc}")
+            return False
 
     def do_python(self, arg: str) -> None:
         args = self.parse_args(arg)
@@ -249,8 +280,15 @@ class ScriptingCommands(BaseCommand):
             return
         filename = args[0]
         if not os.path.exists(filename):
-            ColorPrinter.error(f"File not found: {filename}")
-            return
+            # Bare filename (no path separator) -- try the scripts dir, where
+            # ``examples load`` writes the .py companions of [scpi+py] examples.
+            if os.sep not in filename and "/" not in filename:
+                candidate = os.path.join(self.ctx.get_scripts_dir(), filename)
+                if os.path.exists(candidate):
+                    filename = candidate
+            if not os.path.exists(filename):
+                ColorPrinter.error(f"File not found: {filename}")
+                return
         try:
             with open(filename) as f:
                 script_code = f.read()

--- a/manuals/student/ch01_getting_started.md
+++ b/manuals/student/ch01_getting_started.md
@@ -4,14 +4,16 @@
 
 The SCPI Instrument Toolkit is a Python-based command-line tool for controlling lab instruments -- oscilloscopes, power supplies, multimeters, function generators, source measure units, and USB-to-I2C adapters -- directly from your terminal. Instead of clicking through vendor GUIs or writing full Python programs, you type short commands and get instant results.
 
-The toolkit was built for ESET 453 (Validation and Verification) at Texas A&M University. It supports the instruments in the VOAL lab and works on both personal and managed TAMU machines.
+The toolkit was built for ESET 453 (Validation and Verification) at Texas A&M University. It supports the instruments in the VOAL (Validation and Observation Automation Lab) and works on both personal and managed TAMU machines.
+
+> **Two manuals, one toolkit.** This Student User Manual covers using the toolkit. The companion **TA Developer Guide** (a separate document distributed to TAs) covers adding drivers, REPL commands, examples, and shipping releases. Forward references in this manual that say "see the TA Developer Guide" point to that companion doc, not to a later chapter here.
 
 ## What You Need
 
 Before installing, make sure you have:
 
-- **Python 3.10 or newer** -- Check by running `python --version` in your terminal.
-- **NI-VISA runtime** -- Required for USB and GPIB communication with instruments. Download from https://www.ni.com/en/support/downloads/drivers/download.ni-visa.html
+- **Python 3.10 or newer** -- Check by running `python --version` in your terminal. If you have 3.9 or older, upgrade before installing.
+- **NI-VISA runtime** -- Required for USB and GPIB communication with **real** instruments. Skip this if you only intend to use `--mock` mode. Download from https://www.ni.com/en/support/downloads/drivers/download.ni-visa.html (installation requires admin rights and 5-10 minutes; restart your terminal afterwards).
 
 ## Installation
 
@@ -23,7 +25,7 @@ Open a terminal (PowerShell on Windows, Terminal on Mac/Linux) and run:
 
 ### TAMU managed machines (VOAL lab)
 
-On TAMU-managed Windows machines where admin access is restricted, use the installer script `setup-tamu.ps1` from this repo. It handles PATH issues and installs the toolkit into your user Python directory.
+On TAMU-managed Windows machines where admin access is restricted, use the installer script `setup-tamu.ps1` from this repo. It installs the toolkit into `%APPDATA%\Python` (your user profile) instead of `C:\Program Files`, which sidesteps the admin requirement that blocks a normal `pip install` on managed images. It also adds the user `Scripts` directory to your PATH so `scpi-repl` is callable from any terminal.
 
 **Recommended (safer): download, review, then run**
 
@@ -45,7 +47,7 @@ After installing, verify it works:
 
     scpi-repl --version
 
-You should see something like `scpi-instrument-toolkit v1.0.30`.
+You should see something like `scpi-instrument-toolkit v1.0.x` -- the exact patch number tracks releases on GitHub.
 
 If `scpi-repl` is not recognized, use the module form instead:
 
@@ -77,7 +79,7 @@ This simulates 14 instruments so you can practice commands without being in the 
 When you start the REPL, it automatically scans for connected instruments:
 
     $ scpi-repl --mock
-    ESET Instrument REPL v1.0.30. Type 'help' for commands.
+    ESET Instrument REPL v1.0.x. Type 'help' for commands.
     [INFO] Scanning for instruments in background...
     [SUCCESS] Scan complete: found 14 device(s).
     eset>

--- a/manuals/student/ch04_running_examples.md
+++ b/manuals/student/ch04_running_examples.md
@@ -32,11 +32,15 @@ This copies the example script into your session. You can now see its source:
 
     script show psu_dmm_test
 
-Output shows every line of the script with syntax highlighting.
+`script show` prints every line of the script to the REPL terminal with syntax highlighting (not to a separate editor window).
 
 To load all examples at once:
 
     examples load all
+
+> **`[scpi+py]` examples have two files.** Examples tagged `[scpi+py]` ship with both a `.scpi` script and a `.py` companion that does the data-analysis phase. `examples load <name>` writes both to your scripts directory (`~/Documents/scpi-instrument-toolkit/scripts/`); the SCPI side runs first with `script run <name>` and then chains into the `.py` for analysis. Examples currently tagged `[scpi+py]`: `cross_script_demo`, `complete_cross_script`, `syntax_reference`.
+
+> **`live_*` examples open a matplotlib window.** `live_voltage_sweep`, `live_multi_plot`, `live_freq_sweep`, and `live_combined_plot` need a GUI to render their live plot. If you're on a headless / SSH / managed VM session with no display, set the backend to Agg before launching the REPL: `$env:MPLBACKEND='Agg'` (PowerShell) or `set MPLBACKEND=Agg` (cmd) -- the example still runs end-to-end, it just doesn't pop a window.
 
 ## Running an Example
 

--- a/manuals/student/ch05_lab_workflow.md
+++ b/manuals/student/ch05_lab_workflow.md
@@ -66,22 +66,26 @@ Export to CSV:
 
     log save lab3_data.csv
 
-The CSV file contains columns: Label, Value, Unit, Source. You can open it in Excel or Python.
+The CSV file contains columns: `label`, `value`, `unit`, `source` (all lowercase). You can open it in Excel or Python. `log save` writes to `~/Documents/scpi-instrument-toolkit/data/` by default; type `data dir` in the REPL to see or change the destination.
 
 ## Step 6: Plot in Python
 
-Create a Python script (e.g., `plot_lab3.py`) to generate figures:
+Create a Python script (e.g., `plot_lab3.py`) in the same directory as your CSV (or pass an absolute path to `read_csv`):
 
+    import os, re
     import pandas as pd
     import matplotlib.pyplot as plt
 
-    # Load the CSV
-    df = pd.read_csv("lab3_data.csv")
+    # Load the CSV (use the same path that 'log save' reported, or pass an absolute path)
+    csv_path = os.path.expanduser("~/Documents/scpi-instrument-toolkit/data/lab3_data.csv")
+    df = pd.read_csv(csv_path)
 
-    # Filter voltage sweep data
-    sweep = df[df["Label"].str.startswith("v_")]
-    voltages = [float(label.split("_")[1]) for label in sweep["Label"]]
-    measured = sweep["Value"].values
+    # Keep only sweep rows of the form v_<number> (e.g. v_1.0, v_3.3) so we
+    # don't accidentally include labels like v_set / v_dmm that share the prefix.
+    sweep_re = re.compile(r"^v_\d+(?:\.\d+)?$")
+    sweep = df[df["label"].astype(str).map(lambda s: bool(sweep_re.match(s)))]
+    voltages = [float(label.split("_", 1)[1]) for label in sweep["label"]]
+    measured = sweep["value"].values
 
     # Plot
     plt.figure(figsize=(8, 5))
@@ -100,7 +104,7 @@ Run the script:
 
     python plot_lab3.py
 
-This generates `voltage_accuracy.png` -- a publication-ready figure for your report.
+This generates `voltage_accuracy.png` next to the script.
 
 ## Step 7: Include in Your Report
 

--- a/manuals/student/ch07_scripting.md
+++ b/manuals/student/ch07_scripting.md
@@ -189,11 +189,17 @@ Runs `other_script` from within the current script. Variables are shared between
 
 ## The Debugger
 
-Step through a script one command at a time:
+Step through a script one command at a time.
 
-    script debug my_test
+**Entering the debugger from the REPL:** first record (or load) a script, then launch it under the debugger:
 
-Debugger commands:
+    record start my_test          # or: examples load <name>
+    psu1 chan 1 on
+    v = dmm1 meas unit=V
+    record stop
+    script debug my_test          # prompt changes to (dbg)
+
+Once you see the `(dbg)` prompt, use these single-letter commands to drive execution:
 
 | Command  | Action                        |
 |----------|-------------------------------|

--- a/manuals/student/ch08_multi_instrument.md
+++ b/manuals/student/ch08_multi_instrument.md
@@ -111,6 +111,8 @@ Sweep the PSU through a range of voltages and record DMM readings at each step.
 
 Characterize frequency response by sweeping the AWG and measuring on the scope.
 
+Note: `{f}` inside both **arguments** (`awg1 freq 1 {f}`) and **label names** (`freq_{f} = ...`) is replaced with the current loop value -- so the run produces rows labelled `freq_100`, `freq_500`, etc., which makes the sweep easy to filter later.
+
     awg1 chan 1 on
     awg1 wave 1 sine amp=2.0 offset=0
 

--- a/manuals/student/ch09_data_analysis.md
+++ b/manuals/student/ch09_data_analysis.md
@@ -8,18 +8,26 @@ From the REPL, export your measurement log:
 
     log save lab_data.csv
 
-This creates a CSV file with columns: Label, Value, Unit, Source.
+This creates a CSV file with columns `label`, `value`, `unit`, `source` (all lowercase). The file lands in `~/Documents/scpi-instrument-toolkit/data/` by default; type `data dir` in the REPL to see or change the destination.
 
 ## Loading CSV with pandas
 
-    import pandas as pd
+> **Imports for the whole chapter.** Every snippet below assumes you've run:
+>
+>     import pandas as pd
+>     import matplotlib.pyplot as plt
+>     import numpy as np
+>
+> Add these once at the top of your analysis script.
+
+> **Working directory matters.** `pd.read_csv("lab_data.csv")` looks in the current working directory. Either `cd` to the data directory before launching Python, or pass an absolute path like `pd.read_csv(os.path.expanduser("~/Documents/scpi-instrument-toolkit/data/lab_data.csv"))`.
 
     df = pd.read_csv("lab_data.csv")
     print(df)
 
 Output:
 
-    Label           Value       Unit    Source
+    label           value       unit    source
     v_1.0           0.999847    V       dmm1
     v_2.0           1.999623    V       dmm1
     v_3.3           3.299814    V       dmm1
@@ -27,32 +35,33 @@ Output:
 
 ## Basic Statistics
 
-    print(f"Mean: {df['Value'].mean():.4f}")
-    print(f"Std:  {df['Value'].std():.4f}")
-    print(f"Min:  {df['Value'].min():.4f}")
-    print(f"Max:  {df['Value'].max():.4f}")
+    print(f"Mean: {df['value'].mean():.4f}")
+    print(f"Std:  {df['value'].std():.4f}")
+    print(f"Min:  {df['value'].min():.4f}")
+    print(f"Max:  {df['value'].max():.4f}")
 
 ## Filtering Data
 
-Select specific measurements by label pattern:
+Select specific measurements by label pattern. Watch out for false matches: `startswith("v_")` also picks up labels like `v_set` that aren't numeric -- use a regex to match the sweep pattern strictly.
 
-    # All voltage sweep points
-    sweep = df[df["Label"].str.startswith("v_")]
+    import re
+    sweep_re = re.compile(r"^v_\d+(?:\.\d+)?$")
+
+    # Voltage sweep points only (v_1.0, v_3.3, etc. -- not v_set / v_dmm)
+    sweep = df[df["label"].astype(str).map(lambda s: bool(sweep_re.match(s)))]
 
     # Only measurements from dmm1
-    dmm_data = df[df["Source"] == "dmm1"]
+    dmm_data = df[df["source"] == "dmm1"]
 
     # Only voltage measurements
-    volts = df[df["Unit"] == "V"]
+    volts = df[df["unit"] == "V"]
 
 ## Plotting with matplotlib
 
 ### Line Plot
 
-    import matplotlib.pyplot as plt
-
     voltages_set = [1.0, 2.0, 3.3, 5.0]
-    voltages_measured = sweep["Value"].values
+    voltages_measured = sweep["value"].values
 
     plt.figure(figsize=(8, 5))
     plt.plot(voltages_set, voltages_measured, "bo-", label="Measured")
@@ -138,7 +147,7 @@ If you ran the same test multiple times:
     all_runs = pd.concat([run1, run2, run3], keys=["Run 1", "Run 2", "Run 3"])
 
     # Group by label and compute statistics
-    grouped = all_runs.groupby("Label")["Value"]
+    grouped = all_runs.groupby("label")["value"]
     summary = grouped.agg(["mean", "std", "min", "max"])
     print(summary)
 
@@ -162,9 +171,11 @@ Always use these settings for professional-looking figures:
     df = pd.read_csv("lab_data.csv")
 
     # Extract sweep data -- skip labels we cannot parse as "v_<float>"
-    sweep = df[df["Label"].str.startswith("v_")].copy()
+    sweep = df[df["label"].str.startswith("v_")].copy()
 
     def _parse_setpoint(label):
+        # Returns the float after 'v_', or NaN for non-numeric labels
+        # like 'v_set' / 'v_dmm' that share the prefix.
         parts = label.split("_", 1)
         if len(parts) < 2:
             return np.nan
@@ -173,10 +184,10 @@ Always use these settings for professional-looking figures:
         except ValueError:
             return np.nan
 
-    sweep["set_v"] = sweep["Label"].map(_parse_setpoint)
+    sweep["set_v"] = sweep["label"].map(_parse_setpoint)
     sweep = sweep.dropna(subset=["set_v"])
     set_v = sweep["set_v"].to_numpy()
-    meas_v = sweep["Value"].to_numpy()
+    meas_v = sweep["value"].to_numpy()
 
     # Compute errors. Guard against divide-by-zero when a setpoint is 0 V.
     abs_err = np.abs(meas_v - set_v)

--- a/manuals/student/ch11_troubleshooting.md
+++ b/manuals/student/ch11_troubleshooting.md
@@ -42,15 +42,15 @@ Another program is already connected to the instrument. Close it first:
 - Vendor software (BQStudio, Keysight Connection Expert, NI MAX, etc.)
 - A previous REPL session that crashed without disconnecting
 
-If a previous session crashed:
+If a previous session crashed, find the stuck Python process and terminate it. On TAMU-managed Windows machines, `tasklist` and `taskkill` work without admin rights.
 
-    # On macOS/Linux -- find and kill stuck processes
-    ps aux | grep scpi
-    kill <pid>
-
-    # On Windows
+    # On Windows (TAMU lab machines)
     tasklist | findstr python
     taskkill /PID <pid> /F
+
+    # On macOS / Linux (personal machines only)
+    ps aux | grep scpi
+    kill <pid>
 
 ## Measurements return "9.9e+37"
 
@@ -78,16 +78,15 @@ Install the NI-VISA runtime:
 
     https://www.ni.com/en/support/downloads/drivers/download.ni-visa.html
 
-On Linux, install from the .deb or .rpm package. On macOS, install from the .dmg.
-
-After installing, restart your terminal.
+Installation requires admin rights and takes 5-10 minutes. Restart your terminal afterwards so the new PATH entries take effect. On Linux install from the `.deb` / `.rpm` package; on macOS install from the `.dmg`.
 
 ## NI PXIe-4139 not detected
 
-1. Power cycle the PXIe chassis FIRST
-2. Then reboot the host PC
-3. The chassis must be on before the PC boots -- boot order matters
-4. Verify with NI MAX that the device appears
+The PXIe chassis must be powered on **before** the host PC boots -- if the PC boots first, Windows never enumerates the card and the chassis stays invisible until the next reboot.
+
+1. Power cycle the PXIe chassis FIRST.
+2. Then reboot the host PC.
+3. Verify with NI MAX that the device appears.
 
 ## Serial port permission denied (Linux)
 
@@ -112,7 +111,7 @@ Install Git for Windows from https://git-scm.com/download/win or use the toolkit
 ## REPL crashes or freezes
 
 - Check if an instrument disconnected during a measurement. Reconnect and run `scan`.
-- If the REPL is frozen, press Ctrl+C to interrupt, then Ctrl+D to exit.
+- If the REPL is frozen, press Ctrl+C to interrupt, then type `exit`. On Windows you can also press Ctrl+Z then Enter (Ctrl+D is the POSIX EOF; it does not work in cmd.exe / PowerShell).
 - If Ctrl+C does not work, close the terminal window.
 
 ## Update errors

--- a/manuals/ta-developer/ch01_architecture.md
+++ b/manuals/ta-developer/ch01_architecture.md
@@ -96,9 +96,10 @@ Base class for all SCPI instrument drivers. Provides:
 - `connect()` / `disconnect()` -- VISA session management
 - `send_command(cmd)` -- write a SCPI command
 - `query(cmd)` -- write and read response
-- `get_identity()` -- `*IDN?` query
 - `clear_status()` -- `*CLS` command
 - `reset()` -- `*RST` command
+
+`*IDN?` querying is not on the base class -- drivers that need an identity string call `self.query("*IDN?")` directly, and `InstrumentDiscovery` does the same against every detected VISA resource.
 
 ### InstrumentDiscovery (`lab_instruments/src/discovery.py`)
 

--- a/manuals/ta-developer/ch04_adding_repl_commands.md
+++ b/manuals/ta-developer/ch04_adding_repl_commands.md
@@ -18,7 +18,9 @@ Key methods provided:
 
 ## The Command Handler Pattern
 
-Each instrument type has a command handler class. Here is the PsuCommand pattern from `lab_instruments/repl/commands/psu.py`:
+Each instrument type has a command handler class. Here is the PsuCommand pattern from `lab_instruments/repl/commands/psu.py`. Real handler files start with:
+
+    from lab_instruments.repl.commands.base import BaseCommand, ColorPrinter
 
     class PsuCommand(BaseCommand):
         def execute(self, arg, dev, dev_name):

--- a/manuals/ta-developer/ch10_script_engine.md
+++ b/manuals/ta-developer/ch10_script_engine.md
@@ -21,11 +21,15 @@ File: `lab_instruments/repl/script_engine/expander.py`
         variables: dict[str, str],
         ctx: Any,
         depth: int = 0,
+        parent_vars: dict[str, str] | None = None,
+        exports: dict[str, str] | None = None,
+        _loop_ctx: str = "",
     ) -> list[tuple[str, str]]:
 
 - `lines` -- raw script lines
 - `variables` -- current variable values (for substitution)
 - `depth` -- recursion depth (for nested `call` directives)
+- `parent_vars`, `exports`, `_loop_ctx` -- internal bookkeeping for nested call frames, exported names, and the surrounding loop annotation; pass `None` / `""` from external callers
 - Returns a list of `(command, source_annotation)` tuples
 
 ### For-loop expansion

--- a/manuals/ta-developer/ch12_stm32_bridge.md
+++ b/manuals/ta-developer/ch12_stm32_bridge.md
@@ -1,5 +1,7 @@
 # Chapter 12: The STM32 Bridge (EV2300 Replacement)
 
+> **You cannot complete this chapter without hardware.** It documents an in-house USB-to-I2C adapter and walks through assembly, soldering, firmware flashing, and bench verification. You need: an Adafruit Feather STM32F405 + FeatherWing proto PCB + JST-PH connector + headers + hookup wire + a soldering iron + a BQ76920 EVM to test against (~$25 in parts; ~30 minutes to assemble). Skip this chapter if you're only working on the software side of the toolkit; reading it without the kit is fine for context, but the assembly, soldering, and DFU-flashing steps below all assume you have a unit in front of you.
+
 ## Why we built it
 
 The TI EV2300A USB-to-SMBus bridge is the original "TAMU bench standard" adapter students use to talk to the BQ76920 battery-monitor IC on its EVM board. It is discontinued, and replacement units on the secondary market are expensive and inconsistent. To keep ESET 453 lab kits running past the current supply, we built a drop-in replacement out of an Adafruit Feather STM32F405 + a FeatherWing protoboard.
@@ -75,7 +77,7 @@ The build goes in five stages. Take continuity measurements between stages 3 and
 
 Flash the Feather with the STM32 bridge firmware before handing the unit out.
 
-- **Firmware source:** [`github.com/CesMag/BQ76920_Bridge`](https://github.com/CesMag/BQ76920_Bridge) (public). Build artifacts (`BQ76920_Bridge.bin` / `.elf`) are produced by the repo's CI on every PR and uploaded as workflow artifacts.
+- **Firmware source:** [`github.com/CesMag/BQ76920_Bridge`](https://github.com/CesMag/BQ76920_Bridge) (public). Build artifacts (`BQ76920_Bridge.bin` / `.elf`) are produced by the repo's CI on every PR and uploaded as workflow artifacts. *(Note: this is the single GitHub URL in the project that lives under a personal account instead of the `T-O-M-Tool-Oauto-Mationator` org. The firmware repo predates the org rename and stays where it is so the existing DFU bootloader and CI artifact links keep working; if the org policy in CLAUDE.md changes, plan to migrate it.)*
 - **Flash path:** USB DFU into the STM32F405 ROM bootloader. Move the `B0` jumper on the Feather to `3V3`, press `RESET`, then either run `dfu-util -a 0 --dfuse-address 0x08000000:leave -D BQ76920_Bridge.bin` or use the Adafruit WebDFU page. Move `B0` back to `GND` and press `RESET` to boot the new firmware.
 
 ### USB VID/PID: lab-only reuse
@@ -88,7 +90,9 @@ This reuse is acceptable **only** on closed lab benches and unit-under-test kits
     - Obtain explicit written authorization from TI for the continued use of their VID/PID on this replacement, **or**
     - Rebuild the firmware with a project-owned VID/PID (Adafruit's test-bench range or a pid.codes sublicense are both reasonable options), and update the driver's match table in `lab_instruments/src/ev2300.py` to add the new descriptor alongside the existing TI one.
 
-Record whichever decision was made in this chapter and in `docs/ev2300.md` before any external release.
+Record whichever decision was made in this chapter and in `docs/ev2300.md` before any external release. Use this template so the record is self-explanatory:
+
+> Decision: lab-only VID/PID reuse approved on YYYY-MM-DD by `<TA / instructor name>` for the ESET 453 course only. Not for external distribution. Re-review before any release outside the VOAL lab.
 
 If the bridge comes up in DFU mode (no I2C traffic, `scan` shows a "bootloader" descriptor), reflash. There is no recovery path from the REPL.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpi-instrument-toolkit"
-version = "1.0.52"
+version = "1.0.53"
 description = "Python drivers and interactive REPL for SCPI test and measurement instruments"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Follow-up to PR #119. Fixes the 16 remaining manual defects surfaced by the smoke-test audit so every command shown to a student or TA actually works on a managed Windows machine (no admin, no lab hardware, `--mock` mode).

PR #119 already shipped fixes for the four hard-breaks (D1 `[dev]` extra, D5 `force_scan`, D6 Windows Unicode I/O, D8 pytest stdin under capture). This PR closes the rest:

**Code (2 files):**
- `lab_instruments/repl/commands/scripting.py` — `examples load <name>` now writes the `.py` companion of `[scpi+py]` examples to the scripts dir, and `python <file>` falls back to that dir. Closes **D2** for `cross_script_demo` end-to-end.
- `docs/teststand.md` — fix the two broken intra-page anchor link targets that `mkdocs build` flagged in **D7**.

**Student manual (Ch 1, 4, 5, 7, 8, 9, 11):**
- **D3/D4**: Ch 5 pandas snippet now uses the actual lowercase CSV column names and a regex sweep filter that ignores `v_set` / `v_dmm`.
- **D10**: replace the stale `v1.0.30` banner with `v1.0.x` in Ch 1.
- **D15**: Ch 1 explains the TA Developer Guide is a separate companion document.
- **D16**: Ch 1 explains _why_ `setup-tamu.ps1` works without admin.
- **D17**: Ch 4 documents the `MPLBACKEND=Agg` headless workaround for `live_*` examples.
- **D18**: Ch 7 spells out how to actually enter the debugger from a normal REPL session.
- **D19**: Ch 9 warns that `read_csv` is working-directory-sensitive and consolidates imports at the top.
- **D20**: Ch 11 corrects Ctrl+D → `exit` / Ctrl+Z+Enter on Windows; reorders process cleanup Windows-first; explains the NI PXIe-4139 boot-order consequences.

**TA Developer Guide (Ch 1, 4, 10, 12):**
- **D11**: Ch 1 removes the `get_identity()` line from the `DeviceManager` method list (no such method exists; drivers query `*IDN?` directly).
- **D12**: Ch 10 brings the `expand_script_lines` signature in sync with the current implementation.
- **D13**: Ch 12 annotates the personal-account firmware URL with a rationale for the CLAUDE.md URL-org exception.
- **D14**: Ch 12 leads with a "you cannot complete this chapter without hardware" TLDR.
- Ch 4: show the `BaseCommand` + `ColorPrinter` import line so the snippet is copy-pasteable.

Bumps to **v1.0.53**.

## Test plan

- [x] `ruff check lab_instruments/ tests/` clean
- [x] `ruff format --check lab_instruments/ tests/` clean
- [x] `pytest tests/ -x --tb=line` — 3712 passed
- [x] `mkdocs build` — no new warnings (in particular, the two `teststand.md` anchor warnings from PR #119 are gone)
- [x] `examples load cross_script_demo && script run cross_script_demo` — runs end-to-end, prints "Analysis complete"
- [x] `force_scan` — no TypeError, "Found 14 device(s)"
- [x] `python scripts/validate_doc_examples.py` and `python scripts/validate_all_doc_examples.py` — run to completion on Windows

Out-of-scope for this PR (deliberate, would benefit from issue triage first):
- `complete_cross_script` and `syntax_reference` examples — these hit a pyeval-scoping issue and a script-engine comment-handling quirk that are independent of D2's loader fix. Ch 4 of the student manual now describes the two-file structure honestly so students aren't surprised.
- ~70 lower-severity verbosity / scaffolding findings from `smoke/notes/` (in PR #119's worktree, not this branch). Worth a third pass if/when the manual is being rewritten for clarity, but they don't block accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)