### PR TITLE
Fix #121: Return Value row in §5 NLT steps; close #113: chain setup-teststand from setup-tamu

### DIFF
--- a/docs/teststand.md
+++ b/docs/teststand.md
@@ -332,30 +332,36 @@ In TestStand, **File > New > Sequence File**, then insert three steps in the **M
 1. Right-click → **Insert Step** → **Tests** → **Numeric Limit Test**.
 2. **Step Settings** → **Module** tab:
    - **Module Path**: `teststand_hello.py`
-   - **Function Name**: `get_voltage`
-3. **Arguments** tab: empty (no parameters).
+   - **Function Name**: **pick `get_voltage` from the dropdown** (don't type it). Selecting from the dropdown is what makes TestStand introspect the function signature and auto-add the Return Value row.
+3. **Arguments** tab: confirm a single row appears at the top — `Return Value`, **Value/Expression** = `Step.Result.Numeric`. **If this row is missing, your Measurement will read `0` and the limit check will always fail** ([fix below](#measurement-00-when-the-python-function-returns-a-non-zero-value)). Leave the row alone — `Step.Result.Numeric` is the correct binding.
 4. **Limits** tab:
    - **Comparison Type**: `GELE (>= <=)`
    - **Low**: `4.5`
    - **High**: `5.5`
-5. Leave the **Numeric Measurement** expression at its default — the Python adapter wires the function's return value to it automatically.
-6. Run. Status should be **Passed**, Measurement should be **5.0**. If you see Measurement `0.0` instead, jump to the [Troubleshooting](#measurement-00-when-the-python-function-returns-a-non-zero-value) entry below.
+5. Run. Status should be **Passed**, Measurement should be **5.0**. If you see Measurement `0.0` instead, the Return Value row is missing — re-pick the function from the dropdown to force re-introspection.
 
 ### Step 3 — Numeric Limit Test calling `add` (with parameters)
 
 1. Insert another **Numeric Limit Test** step.
 2. **Module** tab:
    - **Module Path**: `teststand_hello.py`
-   - **Function Name**: `add`
-3. **Arguments** tab: TestStand introspects the function signature and shows two rows, `a` and `b`. **You must fill in the Value/Expression column for each row** — leaving them empty triggers run-time error `-17347: The expression cannot be empty`. Type:
-   - `a` → `3`
-   - `b` → `4`
+   - **Function Name**: **pick `add` from the dropdown** (don't type it).
+3. **Arguments** tab: TestStand introspects the function signature and shows **three rows**:
 
-   Literal numbers (`3`, `4.5`, `True`) are valid expressions. To pass a TestStand variable instead, use the expression syntax (e.g. `Locals.SomeNumber`).
+   | # | Name | Value/Expression | What to do |
+   |---|---|---|---|
+   | 0 | `Return Value` | `Step.Result.Numeric` | Leave alone (this is how the function's return value reaches Measurement). |
+   | 1 | `a` | *(empty)* | **Fill in:** `3` |
+   | 2 | `b` | *(empty)* | **Fill in:** `4` |
+
+   **You must fill in `a` and `b`** — leaving them empty triggers run-time error `-17347: The expression cannot be empty`. Literal numbers (`3`, `4.5`, `True`) are valid expressions; TestStand variables also work (e.g. `Locals.SomeNumber`).
 4. **Limits** tab:
    - **Comparison Type**: `EQ (==)`
    - **Limit**: `7`
 5. Run. Status **Passed**, Measurement **7**.
+
+!!! tip "All Python Numeric Limit Test steps share the same shape"
+    Verified against NI's bundled Python example on TestStand 2025 Q3: every Python adapter Numeric Limit Test step has a `Return Value` row in its Arguments tab with `Step.Result.Numeric` as the expression. That's the channel the function's return value uses to reach Measurement. If you skip the dropdown and type the function name by hand, the row may not get added — pick from the dropdown and the Arguments table populates automatically.
 
 If all three pass, the Python adapter, venv, and DLL load are all wired correctly. Move on.
 
@@ -521,8 +527,9 @@ Open the step's settings → **Arguments** tab → fill every row. Literal value
 
 For a **Numeric Limit Test** step using the Python adapter, the function's return value should populate `Step.Result.Numeric`, which is what the Limits comparison reads. If Measurement shows `0.0` even though your Python `print` shows the right value, walk through this list:
 
-1. **The function returns the value, not just prints it.** `print(voltage)` alone is not enough — the function body needs `return voltage`.
-2. **The function signature matches what TestStand calls.** TestStand passes Arguments-tab values by name; `def get_voltage()` and `def get_voltage(**kwargs)` both work, but a function with required positional args you didn't fill in fails earlier with [-17347](#run-time-error-17347-the-expression-cannot-be-empty).
+1. **Confirm the Arguments tab has a `Return Value` row.** Open the step's settings, **Arguments** tab. The first row must be `Name = Return Value`, `Value/Expression = Step.Result.Numeric`. If the row is missing, TestStand never introspected the function — open the **Module** tab, **re-pick the function from the Function Name dropdown** (don't type it). The Return Value row will populate. Verified against NI's bundled Python example on TestStand 2025 Q3.
+2. **The function returns the value, not just prints it.** `print(voltage)` alone is not enough — the function body needs `return voltage`.
+3. **The function signature matches what TestStand calls.** TestStand passes Arguments-tab values by name; `def get_voltage()` and `def get_voltage(**kwargs)` both work, but a function with required positional args you didn't fill in fails earlier with [-17347](#run-time-error-17347-the-expression-cannot-be-empty).
 3. **The step type is Test - Numeric Limit Test, not Action.** Action steps don't have a measurement.
 4. **The Numeric Measurement expression on the Limits tab is at its default.** The Python adapter wires the return value into `Step.Result.Numeric` for you; if someone edited that expression to read from somewhere else, restore the default.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpi-instrument-toolkit"
-version = "1.0.53"
+version = "1.0.54"
 description = "Python drivers and interactive REPL for SCPI test and measurement instruments"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/setup-tamu.ps1
+++ b/setup-tamu.ps1
@@ -414,6 +414,34 @@ if ($claudeDir) {
 }
 
 # ---------------------------------------------------------------------------
+# Step 9: Chain setup-teststand.ps1 (closes #113)
+# ---------------------------------------------------------------------------
+# Builds the TestStand-compatible venv on H:\, installs the toolkit into
+# it, and auto-configures the TestStand Python Adapter (Display Console,
+# venv path) if TestStand is installed. Refreshes the session PATH first
+# so the venv tools and python are findable.
+Write-Step 9 "Chaining setup-teststand.ps1 to build the TestStand venv..."
+
+$machinePath2 = [Environment]::GetEnvironmentVariable("Path", "Machine")
+$userPath3    = [Environment]::GetEnvironmentVariable("Path", "User")
+$env:Path     = "$machinePath2;$userPath3"
+
+try {
+    $tsScript = Invoke-RestMethod "https://raw.githubusercontent.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit/main/setup-teststand.ps1"
+    $tsTmp = New-TemporaryFile
+    $tsScript | Set-Content -Path $tsTmp -Encoding UTF8
+    # Invoke with -NoPause so a single Enter at the end of setup-tamu still
+    # closes both. The -ProjectName default ("scpi-workspace") is fine.
+    & $tsTmp -NoPause
+    Remove-Item $tsTmp -Force -ErrorAction SilentlyContinue
+    Write-Host "TestStand venv setup complete." -ForegroundColor Green
+} catch {
+    Write-Host "setup-teststand.ps1 failed to run: $_" -ForegroundColor Yellow
+    Write-Host "You can run it manually later:" -ForegroundColor Yellow
+    Write-Host "  irm `"https://raw.githubusercontent.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit/main/setup-teststand.ps1`" | iex" -ForegroundColor Yellow
+}
+
+# ---------------------------------------------------------------------------
 # Done
 # ---------------------------------------------------------------------------
 Write-Host ""


### PR DESCRIPTION
Closes #121, closes #113.

## #121 - Measurement always 0 in §5 Numeric Limit Test steps (verified root cause)

@nashm03-cloud's screenshot shows Step 1 (`check_connection`) Done ✓ but Step 2 (`add`) and Step 3 (`get_voltage`) both **Failed with Measurement `{0}`** — i.e. the function ran but its return value never reached the limit comparison.

Headless COM probe against TestStand 2025 Q3 on this lab machine, inspecting NI's bundled NumericLimitTest+Python example (`UUT Numeric Limit Test` calling `UUTVoltageTest`):

\`\`\`
Module.Parameters.Count = 1
  [0] Name='Return Value'  ValueExpr='Step.Result.Numeric'  Category=7
DataSource = 'Step.Result.Numeric'
Comp = 'GELE'
Limits.Low = 30.0  High = 40.0
\`\`\`

So the channel is: function return → `'Return Value'` row's ValueExpr (`Step.Result.Numeric`) → `DataSource` (Numeric Measurement) → limit comparison. **If the Return Value row is missing, Measurement stays at 0 and every limit fails.** That row is auto-added by TestStand's adapter *when it introspects the function signature* — which happens reliably only if you pick the function from the dropdown rather than typing it.

### Docs changes

\`docs/teststand.md\` §5:

- **Step 2** rewritten: explicitly tell students to **pick `get_voltage` from the Function Name dropdown** (not type). Added an Arguments-tab check: confirm the Return Value row appears with `Step.Result.Numeric`. If missing → re-pick from dropdown to force re-introspect.
- **Step 3** rewritten with a full Arguments-tab table showing all three rows (`Return Value` / `a` / `b`) and what to fill in for each. Keeps the existing `-17347` callout for empty `a`/`b`.
- Added a tip callout: "All Python NLT steps share the same shape" — verified against NI's example.
- Troubleshooting **Measurement = 0.0** entry's first bullet is now the verified Return Value fix.

## #113 - chain setup-teststand from setup-tamu

\`setup-tamu.ps1\` gains a new **Step 9** that:

1. Refreshes the session PATH so the freshly-installed Python is callable in this shell.
2. Downloads \`setup-teststand.ps1\` from \`main\` and runs it with \`-NoPause\`.
3. Failure is non-fatal — prints a manual-retry one-liner and continues.

End result: a fresh TAMU lab machine goes from zero to a working venv + a fully-configured TestStand Python Adapter (Display Console enabled, venv path set, all #117/#120/#122 work folded in) in a single \`irm setup-tamu.ps1 | iex\`.

Bump to 1.0.54.

## Verified findings (this lab machine, TestStand 2025 Q3, 64-bit)

- The Return Value row's ValueExpr always points at \`Step.Result.Numeric\` on NI's NLT example — that's what the docs §5 tip now states.
- Setting \`PythonAdapter.PythonVirtualEnvironmentPath\` and \`DisplayConsoleForInterpreterSessions\` via COM persists across engine restarts (verified earlier in PR #122).
- The chained \`setup-teststand.ps1\` already exits clean on idempotent re-runs (verified during #114/#115 testing).

## Test plan

- [x] COM probe verifies the Return Value row / DataSource / Step.Result.Numeric chain on NI's own example.
- [ ] CI green on PR.
- [ ] @nashm03-cloud opens an existing Step 2 / Step 3 in their sequence, checks the Arguments tab, and if Return Value is missing re-picks the function from the dropdown. Both NLT steps should now report Passed with the expected Measurement.
- [ ] Fresh \`irm setup-tamu.ps1 | iex\` on a clean lab machine completes through Step 9 with the TestStand venv built and adapter auto-configured.