### PR TITLE
Fix #110 + #96: bump GitHub Actions off Node 20; add INSTALL.md + vendor-drivers section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -79,10 +79,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -134,7 +134,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-py${{ matrix.python-version }}
           path: reports/
@@ -149,10 +149,10 @@ jobs:
     needs: lint
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -177,10 +177,10 @@ jobs:
     needs: lint
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -206,7 +206,7 @@ jobs:
     needs: test
     steps:
       - name: Download Python 3.12 test artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: test-results-py3.12
           path: reports/

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: Check dependency graph support
         id: depgraph
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -56,10 +56,10 @@ jobs:
 
       - name: Checkout repository
         if: steps.depgraph.outputs.supported == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Scan dependencies for vulnerabilities
         if: steps.depgraph.outputs.supported == 'true'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,9 +31,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,12 +44,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch || 'dev/nightly' }}
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -74,13 +74,13 @@ jobs:
     needs: test
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch || 'dev/nightly' }}
           fetch-depth: 0
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -140,7 +140,7 @@ jobs:
           sha256sum dist/*
 
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nightly-dist
           path: dist/
@@ -157,13 +157,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch || 'dev/nightly' }}
           fetch-depth: 0
 
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nightly-dist
           path: dist/
@@ -196,7 +196,7 @@ jobs:
           git push origin nightly --force
 
       - name: Create or update nightly release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: nightly
           name: "Nightly Build"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -78,10 +78,10 @@ jobs:
     needs: validate-version
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -108,10 +108,10 @@ jobs:
     needs: test
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -138,7 +138,7 @@ jobs:
           sha256sum dist/*
 
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -156,12 +156,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository (for git log)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -197,7 +197,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           body: ${{ steps.changelog.outputs.body }}

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,60 @@
+# Installation — short version
+
+> One-page install guide. For the full reference (platform-specific notes, every vendor driver, troubleshooting), see [`docs/install.md`](docs/install.md).
+
+## 1. Install the toolkit
+
+The toolkit is not on PyPI. Install from GitHub:
+
+```bash
+pip install "git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git"
+```
+
+Requires **Python 3.10 or later** and `git` on PATH.
+
+**TAMU managed laptops:** admin is restricted, so a normal `pip install` fails. Use the bundled installer instead:
+
+```powershell
+irm "https://raw.githubusercontent.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit/main/setup-tamu.ps1" -OutFile setup-tamu.ps1
+notepad setup-tamu.ps1     # skim before running anything from the internet
+powershell -ExecutionPolicy Bypass -File .\setup-tamu.ps1
+```
+
+It installs to `%APPDATA%\Python` (your user profile), so no admin is needed.
+
+## 2. Verify
+
+```bash
+scpi-repl --mock
+```
+
+You should see the REPL banner and `eset>` prompt. `--mock` simulates 14 devices, so this works without any real hardware. See `help` once you're in.
+
+## 3. Vendor drivers (only if you have real hardware)
+
+Skip this whole section if you're only going to use `--mock` mode.
+
+| Driver | When you need it | Install |
+|---|---|---|
+| **NI-VISA runtime** | Any USB-TMC, GPIB, or VXI-11 / HiSLIP instrument (Keysight DMMs/PSUs, Rigol scopes, Tektronix scopes, BK function generators, etc.) | [ni.com/en/support/downloads/drivers/download.ni-visa.html](https://www.ni.com/en/support/downloads/drivers/download.ni-visa.html) — admin required, ~5–10 min, restart terminal afterwards |
+| **NI-DCPower** | NI PXIe-4139 SMU only | [ni.com → DCPower](https://www.ni.com/en/support/downloads/drivers.html) + `pip install nidcpower` |
+| **EV2300 / STM32 bridge** | BQ76920 battery-monitor labs | Enumerates as USB-HID — no separate vendor driver; `pip install "scpi-instrument-toolkit[hid] @ git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git"` adds the Python `hidapi` binding |
+
+Optional vendor utilities (Keysight Connection Expert, NI MAX, TI BQStudio) are useful for troubleshooting but **never required** by the toolkit itself.
+
+## 4. Upgrading
+
+```bash
+pip install --upgrade "git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git"
+```
+
+To pull the latest nightly instead of the most recent stable tag:
+
+```bash
+pip install --upgrade --force-reinstall "git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git@dev/nightly"
+```
+
+## 5. If something breaks
+
+- Toolkit-side issues: see the [Troubleshooting](https://t-o-m-tool-oauto-mationator.github.io/scpi-instrument-toolkit/troubleshooting/) page.
+- Driver-side issues (NI MAX doesn't see your instrument, EV2300 fails to enumerate, etc.): close any other program that might be holding the resource (only one app can own a VISA handle at a time), then `force_scan` from the REPL.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ pip install "git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-
 
 > You also need [NI-VISA](https://www.ni.com/en/support/downloads/drivers/download.ni-visa.html) to talk to real instruments. Skip it and use `--mock` to try everything without hardware.
 
+For a one-page driver-install reference (NI-VISA, NI-DCPower, EV2300, vendor utilities) see [INSTALL.md](INSTALL.md); for the full guide with platform notes and troubleshooting, see [docs/install.md](docs/install.md).
+
 ---
 
 ## Start the REPL

--- a/docs/install.md
+++ b/docs/install.md
@@ -110,3 +110,63 @@ To pull the latest nightly:
 ```bash
 pip install --upgrade --force-reinstall "git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git@dev/nightly"
 ```
+
+---
+
+## Vendor drivers
+
+The Python install above is enough for `--mock` mode and any instruments that speak SCPI over an OS-native serial / Ethernet path. **Real hardware needs the matching vendor driver installed once per machine.** Pick only the drivers for the instruments you actually have.
+
+### NI-VISA runtime — required for almost every real instrument
+
+NI-VISA is the underlying VISA backend that the toolkit's `pyvisa` dependency talks to. You need it for:
+
+- Any **USB-TMC** instrument (Keysight DMMs / PSUs, Rigol scopes, Tektronix scopes, BK function generators, etc.)
+- Any **GPIB** instrument
+- Any **VXI-11 / HiSLIP** instrument over Ethernet
+
+Skip this only if every instrument you plan to use is mocked, raw serial (`/dev/ttyUSB*`, COMx with no VISA), or accessed through a non-VISA driver below.
+
+1. Download the runtime from [ni.com/en/support/downloads/drivers/download.ni-visa.html](https://www.ni.com/en/support/downloads/drivers/download.ni-visa.html).
+2. Run the installer. **Admin rights required**, takes about 5–10 minutes on Windows.
+3. Restart your terminal so the new PATH entries take effect.
+4. Verify with `python -c "import pyvisa; print(pyvisa.ResourceManager().list_resources())"` — you should see `('ASRLn::INSTR', ...)` style strings and no `OSError`.
+
+!!! note "TAMU managed machines"
+    NI-VISA installs cleanly on TAMU-managed Windows machines because the installer is signed and submitted through the standard MSI path. You still need the admin password / TA assist for the one-time install.
+
+### NI-DCPower — only if you have an NI PXIe-4139 SMU
+
+If you're driving an NI PXIe-4139 source-measure unit, install the NI-DCPower driver **and** the Python binding:
+
+1. Download NI-DCPower from [ni.com/downloads/drivers/](https://www.ni.com/en/support/downloads/drivers.html) (admin required).
+2. After NI-DCPower is installed, add the Python binding:
+
+    ```bash
+    pip install nidcpower
+    ```
+
+The toolkit's PXIe-4139 driver imports `nidcpower` at scan time — without it, the SMU won't enumerate.
+
+### EV2300 USB-to-I2C bridge — no separate driver needed
+
+The original TI EV2300A enumerates as a generic USB-HID device on all three OSes; the toolkit talks to it via `hidapi` (pulled in by the `hid` extra). To install the optional `hid` extra:
+
+```bash
+pip install "scpi-instrument-toolkit[hid] @ git+https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit.git"
+```
+
+If your kit ships an in-house STM32 replacement instead (Adafruit Feather STM32F405 + FeatherWing), no additional setup is needed at runtime — the bridge enumerates with the same USB descriptor and the existing driver picks it up. Re-flashing the firmware does need extra tools; see the **Flashing the STM32 bridge** section in the [TA Developer Guide Ch 12](https://github.com/T-O-M-Tool-Oauto-Mationator/scpi-instrument-toolkit/blob/main/manuals/ta-developer/ch12_stm32_bridge.md).
+
+### Vendor utilities — only for one-off troubleshooting
+
+You don't need these to use the toolkit, but TAs and instructors usually install them on lab bench machines so they can fall back to vendor software for cross-checks:
+
+- **Keysight Connection Expert** — verifies Keysight USB / GPIB / LXI links; ships with the IO Libraries Suite.
+- **NI MAX** — bundled with NI-VISA. Useful for checking that VISA can see your instruments before launching the REPL.
+- **TI BQStudio** — only relevant if you're working with the BQ76920 EVM via the EV2300 bridge.
+
+All three are admin-installer-required Windows-only tools. Skip if you don't already use them.
+
+!!! warning "Only one program can hold a VISA resource at a time"
+    If `scan` in the REPL reports "Resource busy" or "Cannot open resource", close NI MAX / Keysight Connection Expert / a second `scpi-repl` first. The lock is exclusive.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpi-instrument-toolkit"
-version = "1.0.54"
+version = "1.0.55"
 description = "Python drivers and interactive REPL for SCPI test and measurement instruments"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scpi-instrument-toolkit"
-version = "1.0.53"
+version = "1.0.54"
 description = "Python drivers and interactive REPL for SCPI test and measurement instruments"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Two unrelated housekeeping issues bundled because they touch independent files. Closes **#110** (Actions Node 20 deprecation) and **#96** (simpler install docs).

### #110 — GitHub Actions Node 20 deprecation (commit 224c709)

The forced bump to Node 24 lands on **2026-06-02** (19 days away). Bumping every action we use to its current major now, ahead of the deadline:

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-python` | v5 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `actions/github-script` | v7 | v9 |
| `actions/dependency-review-action` | v4 | v5 |
| `softprops/action-gh-release` | v2 | v3 |

Applied across `ci.yml`, `dependency-review.yml`, `docs.yml`, `nightly.yml`, `release.yml`. No workflow logic changed — only the version pins. CI on this PR is the real test that the bumps don't break anything.

### #96 — Simpler install docs (commit f95274e)

The existing `docs/install.md` covers the Python toolkit install but the vendor-driver side (NI-VISA, NI-DCPower, EV2300 `hidapi` extra) was only documented inside Student Manual Ch 1, wrapped in ESET-453 context. New readers — especially TAs onboarding to a new bench — had no scannable driver reference.

- `docs/install.md`: append a "Vendor drivers" section. Each driver gets when-you-need-it + how-to-install + admin/restart caveat. Calls out the one-VISA-client-at-a-time lock that causes most "Resource busy" reports.
- `INSTALL.md` (new): short one-page guide at the repo root. GitHub auto-renders it under the README on the repo home page, so it's findable without diving into the docs site.
- `README.md`: a single-line forward link from the existing install paragraph into both new docs.

### Versions

Bumped per CLAUDE.md commit convention: 1.0.53 → 1.0.54 (#110) → 1.0.55 (#96).

### Also done in this session, not in this PR

- **#92** (EV2300 + BQ76920 live integration test) closed as fixed — STM32 bridge firmware landed in PR #119's chain; live I2C now works.
- **#109** (PyPI publish from release.yml) closed as won't-do — the current `git+https://...` install flow is enough for the actual audience and trusted publishing would add CI complexity for a package without external distribution requirements.

## Test plan

- [x] `ruff check lab_instruments/ tests/` clean
- [x] `ruff format --check lab_instruments/ tests/` clean
- [x] `pytest tests/ -x --tb=line` — 3712 passed
- [x] `mkdocs build` — no new warnings (pre-existing griffe warnings unchanged)
- [ ] CI on this PR — the version bumps validate themselves by passing CI; if anything regressed under the new action majors, this PR's checks will show it

🤖 Generated with [Claude Code](https://claude.com/claude-code)